### PR TITLE
Connect backend to external Qdrant

### DIFF
--- a/backend/FlashcardsApi/Program.cs
+++ b/backend/FlashcardsApi/Program.cs
@@ -67,9 +67,16 @@ else if (provider == "InMemory")
 }
 else if (provider == "Qdrant")
 {
-    // Qdrant DB support (host: 10.0.0.19, port: 6334)
-    builder.Services.AddSingleton<IFlashcardService>(sp => new QdrantFlashcardService("10.0.0.19", 6334));
-    builder.Services.AddSingleton<ILearningPathService>(sp => new QdrantLearningPathService("10.0.0.19", 6334));
+    // Qdrant DB support via environment variables
+    var qdrantHost = Environment.GetEnvironmentVariable("QDRANT_HOST") ?? "host.docker.internal";
+    var qdrantPortStr = Environment.GetEnvironmentVariable("QDRANT_PORT") ?? "6334";
+    if (!int.TryParse(qdrantPortStr, out var qdrantPort))
+    {
+        throw new InvalidOperationException($"Invalid QDRANT_PORT: {qdrantPortStr}");
+    }
+
+    builder.Services.AddSingleton<IFlashcardService>(sp => new QdrantFlashcardService(qdrantHost, qdrantPort));
+    builder.Services.AddSingleton<ILearningPathService>(sp => new QdrantLearningPathService(qdrantHost, qdrantPort));
     // TODO: Add QdrantTopicService if needed
 }
 else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: '3.8'
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
-    container_name: elasticsearch
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-    ports:
-      - "9200:9200"
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-
   backend:
     build: ./backend
     container_name: flashcards-api
@@ -18,9 +7,9 @@ services:
       - "5000:80"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ELASTIC_URI=http://elasticsearch:9200
-    depends_on:
-      - elasticsearch
+      - Storage__Provider=Qdrant
+      - QDRANT_HOST=host.docker.internal
+      - QDRANT_PORT=6334
 
   frontend:
     build: ./frontend
@@ -29,6 +18,3 @@ services:
       - "4200:80"
     depends_on:
       - backend
-
-volumes:
-  esdata:


### PR DESCRIPTION
## Summary
- load Qdrant connection info from `QDRANT_HOST` and `QDRANT_PORT`
- simplify `docker-compose.yml` to run just backend and frontend
- configure backend service to use Qdrant

## Testing
- `dotnet build` *(fails: dotnet not found)*
- `docker compose config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df28a7f60832a9d84904db7591936