### PR TITLE
Fix LearningPath imports

### DIFF
--- a/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
+++ b/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MenuComponent } from '../menu/menu.component';
 import { FormsModule } from '@angular/forms';
 import { LearningPathService } from '../services/learning-path.service';
-import { LearningPath } from '../models/learningPath';
+import { LearningPath } from '../models/LearningPath';
 import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';
 import { HttpClientModule } from '@angular/common/http';

--- a/frontend/flashcards-ui/src/app/services/learning-path.service.ts
+++ b/frontend/flashcards-ui/src/app/services/learning-path.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { LearningPath } from '../models/learningPath';
+import { LearningPath } from '../models/LearningPath';
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary
- correct LearningPath import paths to match filename

## Testing
- `dotnet test backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj --no-build` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684df88db110832aa3aeaf13f6e00c7d