### PR TITLE
Update frontend to auto detect API url

### DIFF
--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -3,9 +3,14 @@ import { HttpClient } from '@angular/common/http';
 import { Deck } from '../models/deck';
 import { Observable } from 'rxjs';
 
+const API_BASE_URL =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:5000'
+    : 'http://backend:80';
+
 @Injectable({ providedIn: 'root' })
 export class DeckService {
-  private apiUrl = 'http://localhost:5000/decks';
+  private apiUrl = `${API_BASE_URL}/decks`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/flashcards-ui/src/app/services/flashcard.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard.service.ts
@@ -3,6 +3,11 @@ import { Injectable } from '@angular/core';
 import { Flashcard } from '../models/flashcard';
 import { Observable } from 'rxjs';
 
+const API_BASE_URL =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:5000'
+    : 'http://backend:80';
+
 function isUuidObject(id: unknown): id is { uuid: string } {
   return (
     typeof id === 'object' && id !== null && 'uuid' in id && typeof (id as any).uuid === 'string'
@@ -28,7 +33,7 @@ function normalizeId(id: unknown): string {
 
 @Injectable({ providedIn: 'root' })
 export class FlashcardService {
-  private apiUrl = 'http://localhost:5000/flashcards';
+  private apiUrl = `${API_BASE_URL}/flashcards`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/flashcards-ui/src/app/services/learning-path.service.ts
+++ b/frontend/flashcards-ui/src/app/services/learning-path.service.ts
@@ -3,9 +3,14 @@ import { Injectable } from '@angular/core';
 import { LearningPath } from '../models/LearningPath';
 import { Observable } from 'rxjs';
 
+const API_BASE_URL =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:5000'
+    : 'http://backend:80';
+
 @Injectable({ providedIn: 'root' })
 export class LearningPathService {
-  private apiUrl = 'http://localhost:5000/api/learning-paths';
+  private apiUrl = `${API_BASE_URL}/api/learning-paths`;
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- compute API base URL from runtime host
- use this base URL in flashcard, deck, and learning path services

## Testing
- `npm --prefix frontend/flashcards-ui test` *(fails: ng not found)*
- `dotnet test backend/FlashcardsApi.Tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7d44c458832a822b0c8801e47883