### PR TITLE
Fix API URL for external hosts

### DIFF
--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 const API_BASE_URL =
   window.location.hostname === 'localhost'
     ? 'http://localhost:5000'
-    : 'http://backend:80';
+    : `http://${window.location.hostname}:5000`;
 
 @Injectable({ providedIn: 'root' })
 export class DeckService {

--- a/frontend/flashcards-ui/src/app/services/flashcard.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 const API_BASE_URL =
   window.location.hostname === 'localhost'
     ? 'http://localhost:5000'
-    : 'http://backend:80';
+    : `http://${window.location.hostname}:5000`;
 
 function isUuidObject(id: unknown): id is { uuid: string } {
   return (

--- a/frontend/flashcards-ui/src/app/services/learning-path.service.ts
+++ b/frontend/flashcards-ui/src/app/services/learning-path.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 const API_BASE_URL =
   window.location.hostname === 'localhost'
     ? 'http://localhost:5000'
-    : 'http://backend:80';
+    : `http://${window.location.hostname}:5000`;
 
 @Injectable({ providedIn: 'root' })
 export class LearningPathService {


### PR DESCRIPTION
## Summary
- update service base URLs to use host IP when not localhost

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8412cd8c832a9bddd86c3085f98b