### PR TITLE
Fix API container port

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-preview AS base
 WORKDIR /app
+# The ASP.NET base image listens on port 8080 by default via ASPNETCORE_URLS.
+# Override it to ensure the API runs on port 80 as expected by docker-compose.
+ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0-preview AS build


### PR DESCRIPTION
## Summary
- ensure backend container listens on port 80

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8696a388832a85bdfbab7570ee2e