### PR TITLE
Add Qdrant to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ dotnet build
 dotnet test
 ```
 
+### Docker Compose
+
+Spin up the entire stack (backend, frontend and Qdrant database) using Docker Compose:
+
+```bash
+docker-compose up
+```
+
 ### API Docs (Swagger)
 Visit [http://localhost:5000/swagger](http://localhost:5000/swagger)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,17 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - Storage__Provider=Qdrant
-      - QDRANT_HOST=host.docker.internal
+      - QDRANT_HOST=qdrant
       - QDRANT_PORT=6334
       - OpenAI__ApiKey=${OPENAI_API_KEY}
+    depends_on:
+      - qdrant
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
   frontend:
     build:
       context: ./frontend/flashcards-ui


### PR DESCRIPTION
## Summary
- use container name `qdrant` for Qdrant host
- add Qdrant service and make backend depend on it
- document docker compose usage in README

## Testing
- `dotnet test backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e87c186b0832aa3b66a90a095a1d3