### PR TITLE
Fix qdrant volume definition in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,3 +31,6 @@ services:
       - "4200:80"
     depends_on:
       - backend
+
+volumes:
+  qdrant_data:


### PR DESCRIPTION
## Summary
- define `qdrant_data` named volume in `docker-compose.yml`

## Testing
- `dotnet test backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8afcae34832aaa5fc97b6c527da1