### PR TITLE
Improve responsive layout

### DIFF
--- a/frontend/flashcards-ui/angular.json
+++ b/frontend/flashcards-ui/angular.json
@@ -31,7 +31,9 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
           },
           "configurations": {
             "production": {
@@ -89,7 +91,9 @@
             "styles": [
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
           }
         }
       }

--- a/frontend/flashcards-ui/src/app/about/about.component.html
+++ b/frontend/flashcards-ui/src/app/about/about.component.html
@@ -1,6 +1,6 @@
 <app-menu></app-menu>
 
-<div class="container mt-4">
+<div class="container-fluid mt-4">
     <h2>About Flashcards App</h2>
     <p>This application is designed to help you learn and memorize technical concepts using interactive flashcards.</p>
 

--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
@@ -1,8 +1,10 @@
 <app-menu></app-menu>
-<div class="bulk-import-container">
+<div class="container-fluid mt-4">
+  <div class="bulk-import-container">
   <h2>Bulk Import Flashcards to Qdrant</h2>
   <input type="file" accept="application/json" (change)="onFileSelected($event)">
   <div *ngIf="loading" class="loading">Uploading...</div>
   <div *ngIf="uploadResult" [ngClass]="{'upload-result': !uploadResult.startsWith('Import failed'), 'upload-error': uploadResult.startsWith('Import failed')}">{{ uploadResult }}</div>
   <button class="btn btn-outline-primary mb-3" (click)="exportFlashcards()">Export Flashcards as JSON</button>
+  </div>
 </div>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -1,6 +1,6 @@
 <app-menu></app-menu>
 
-<div class="container mt-4">
+<div class="container-fluid mt-4">
     <h2>Manage Flashcards</h2>
 
     <div class="mb-3">
@@ -23,6 +23,7 @@
         <button class="btn btn-primary" type="submit">{{ newFlashcard.id ? 'Update' : 'Add' }}</button>
     </form>
 
+    <div class="table-responsive">
     <table class="table table-striped">
         <thead>
             <tr>
@@ -44,4 +45,5 @@
             </tr>
         </tbody>
     </table>
+    </div>
 </div>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
@@ -1,6 +1,6 @@
 <app-menu></app-menu>
 
-<div class="container mt-5" *ngIf="flashcards.length > 0 && !allPassed()">
+<div class="container-fluid mt-5" *ngIf="flashcards.length > 0 && !allPassed()">
   <div class="card shadow-lg">
     <div class="card-body text-center">
       <h5 class="card-title mb-4">Card {{ currentIndex + 1 }} of {{ flashcards.length }}</h5>
@@ -21,6 +21,6 @@
   </div>
 </div>
 
-<div class="container mt-5 text-center" *ngIf="allPassed()">
+<div class="container-fluid mt-5 text-center" *ngIf="allPassed()">
   <h2 class="text-success">🎉 All flashcards passed with score > 2!</h2>
 </div>

--- a/frontend/flashcards-ui/src/app/help-page/help-page.component.html
+++ b/frontend/flashcards-ui/src/app/help-page/help-page.component.html
@@ -1,6 +1,6 @@
 <app-menu></app-menu>
 
-<div class="container mt-4">
+<div class="container-fluid mt-4">
     <h2>Help & FAQs</h2>
 
     <h5>❓ How do I use flashcards?</h5>

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -1,6 +1,6 @@
 <app-menu></app-menu>
 
-<div class="container mt-4">
+<div class="container-fluid mt-4">
   <div class="row mb-4">
     <div class="col-12">
       <div class="card w-100 shadow-sm">
@@ -12,12 +12,12 @@
     </div>
   </div>
   <div class="row mb-3">
-    <div class="col-md-6 mx-auto">
+    <div class="col-12 col-md-6 mx-auto">
       <input type="text" class="form-control" placeholder="Filter decks..." [(ngModel)]="filterText">
     </div>
   </div>
   <div class="row">
-    <div class="col-md-4" *ngFor="let deck of filteredDecks">
+    <div class="col-12 col-sm-6 col-lg-4 col-xl-3" *ngFor="let deck of filteredDecks">
       <div class="card mb-4 shadow" (click)="selectDeck(deck)" style="cursor: pointer;">
         <div class="card-body">
           <h5 class="card-title">{{ deck.name || deck.id }}</h5>

--- a/frontend/flashcards-ui/src/app/learning-path/learning-path.component.html
+++ b/frontend/flashcards-ui/src/app/learning-path/learning-path.component.html
@@ -1,5 +1,5 @@
 <app-menu></app-menu>
-<div class="container mt-4">
+<div class="container-fluid mt-4">
     <h2>Learning Paths</h2>
 
     <!-- Form: Create New Path (including flashcard selector) -->

--- a/frontend/flashcards-ui/src/app/menu/menu.component.html
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.html
@@ -1,7 +1,10 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
     <div class="container-fluid">
         <a class="navbar-brand" routerLink="/">📚 Flashcards</a>
-        <div class="collapse navbar-collapse">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNavbar">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
                     <a class="nav-link" routerLink="/">Home</a>


### PR DESCRIPTION
## Summary
- add responsive navbar toggler
- widen page containers to fluid layout for all screens
- show deck list grid with responsive columns
- make admin table scrollable on mobile
- bundle bootstrap JS for navbar

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512425a614832aac55e805399e57e1