### PR TITLE
Add Angular PWA support

### DIFF
--- a/frontend/flashcards-ui/angular.json
+++ b/frontend/flashcards-ui/angular.json
@@ -24,7 +24,8 @@
               {
                 "glob": "**/*",
                 "input": "public"
-              }
+              },
+              "src/manifest.webmanifest"
             ],
             "styles": [
               "src/styles.css",
@@ -33,7 +34,9 @@
             ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
-            ]
+            ],
+            "serviceWorker": true,
+            "ngswConfigPath": "src/ngsw-config.json"
           },
           "configurations": {
             "production": {

--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/platform-server": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "@angular/service-worker": "^19.2.0",
     "@angular/ssr": "^19.2.11",
     "bootstrap": "^5.3.6",
     "express": "^4.18.2",

--- a/frontend/flashcards-ui/src/app/app.config.ts
+++ b/frontend/flashcards-ui/src/app/app.config.ts
@@ -2,6 +2,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
+import { provideServiceWorker } from '@angular/service-worker';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -9,6 +10,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideClientHydration(withEventReplay()),
     provideHttpClient(withFetch()),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideServiceWorker('ngsw-worker.js')
   ]
 };

--- a/frontend/flashcards-ui/src/index.html
+++ b/frontend/flashcards-ui/src/index.html
@@ -5,6 +5,8 @@
   <title>FlashcardsUi</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1976d2">
+  <link rel="manifest" href="manifest.webmanifest">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>

--- a/frontend/flashcards-ui/src/manifest.webmanifest
+++ b/frontend/flashcards-ui/src/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Flashcards UI",
+  "short_name": "Flashcards",
+  "theme_color": "#1976d2",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "scope": "/",
+  "start_url": "/",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/frontend/flashcards-ui/src/ngsw-config.json
+++ b/frontend/flashcards-ui/src/ngsw-config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/favicon.ico",
+          "/*.css",
+          "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/**",
+          "/*.(png|jpg|svg)"
+        ]
+      }
+    }
+  ],
+  "dataGroups": [
+    {
+      "name": "decks-api",
+      "urls": [
+        "http://localhost:5000/decks",
+        "http://localhost:5000/decks/**"
+      ],
+      "cacheConfig": {
+        "strategy": "freshness",
+        "maxSize": 20,
+        "maxAge": "1d",
+        "timeout": "10s"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `@angular/service-worker` dependency
- register service worker in the application config
- enable service worker build options
- provide PWA manifest and service worker config
- update index with manifest link and theme color

## Testing
- `npm test` *(fails: `ng` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685416673178832a8731bd3edbc98ac2