### PR TITLE
Fix offline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An interactive flashcard-based learning platform that allows users to study, cre
 - 🔍 Filter flashcards by question text
 - 🌐 Fully functional REST API
 - 💾 Dual backend support: InMemory, MongoDB, or Elasticsearch
+- 📱 Installable PWA with offline support (caches decks and flashcards)
 
 ---
 
@@ -77,6 +78,13 @@ An interactive flashcard-based learning platform that allows users to study, cre
 cd frontend/flashcards-ui
 npm install
 ng serve
+```
+
+When accessing the app from another device, use HTTPS so the service worker can
+register and display the install icon:
+
+```bash
+ng serve --ssl --host 0.0.0.0
 ```
 
 ### Run Backend

--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -8,7 +8,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:flashcards-ui": "node dist/flashcards-ui/server/server.mjs",
-    "serve:prod": "npm run build && npx http-server dist/flashcards-ui/browser"
+    "serve:prod": "npm run build && npx http-server dist/flashcards-ui/browser",
+    "serve:prod:https": "npm run build && npx http-server dist/flashcards-ui/browser -S"
   },
   "private": true,
   "dependencies": {

--- a/frontend/flashcards-ui/src/ngsw-config.json
+++ b/frontend/flashcards-ui/src/ngsw-config.json
@@ -29,12 +29,29 @@
     {
       "name": "decks-api",
       "urls": [
-        "http://localhost:5000/decks",
-        "http://localhost:5000/decks/**"
+        "/decks",
+        "/decks/**",
+        "http://backend:5000/decks",
+        "http://backend:5000/decks/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",
         "maxSize": 20,
+        "maxAge": "1d",
+        "timeout": "10s"
+      }
+    },
+    {
+      "name": "flashcards-api",
+      "urls": [
+        "/flashcards",
+        "/flashcards/**",
+        "http://backend:5000/flashcards",
+        "http://backend:5000/flashcards/**"
+      ],
+      "cacheConfig": {
+        "strategy": "freshness",
+        "maxSize": 100,
         "maxAge": "1d",
         "timeout": "10s"
       }


### PR DESCRIPTION
## Summary
- add HTTPS note for PWA install on other devices
- cache deck API URLs with relative paths
- add `serve:prod:https` script for HTTPS testing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c1add9fc832aa7129501f7717817