### PR TITLE
Remove unused MenuComponent imports

### DIFF
--- a/frontend/flashcards-ui/src/app/about/about.component.ts
+++ b/frontend/flashcards-ui/src/app/about/about.component.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MenuComponent } from '../menu/menu.component';
 
 @Component({
   selector: 'app-about',
   standalone: true,
-  imports: [CommonModule, MenuComponent],
+  imports: [CommonModule],
   templateUrl: './about.component.html',
   styleUrl: './about.component.css'
 })

--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
@@ -2,14 +2,13 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { FlashcardBulkExportService } from './flashcard-bulk-export.service';
-import { MenuComponent } from '../menu/menu.component';
 import { FormsModule } from '@angular/forms';
 import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-bulk-import',
   standalone: true,
-  imports: [CommonModule, MenuComponent, FormsModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './flashcard-bulk-import.component.html',
   styleUrls: ['./flashcard-bulk-import.component.css']
 })

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -3,13 +3,12 @@ import { Flashcard } from '../../models/flashcard';
 import { FlashcardService } from '../../services/flashcard.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MenuComponent } from '../../menu/menu.component';
 import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-flashcard-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, MenuComponent, RouterModule],
+  imports: [CommonModule, FormsModule, RouterModule],
   templateUrl: './flashcard-admin.component.html',
   styleUrls: ['./flashcard-admin.component.css']
 })

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
@@ -4,7 +4,6 @@ import { FlashcardService } from '../services/flashcard.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { MenuComponent } from '../menu/menu.component';
 import { AuthService } from '../services/auth.service';
 
 function isUuidObject(id: unknown): id is { uuid: string } {
@@ -24,7 +23,7 @@ function normalizeId(id: unknown): string {
   selector: 'app-flashcard',
   templateUrl: './flashcard.component.html',
   styleUrls: ['./flashcard.component.css'],
-  imports: [CommonModule, FormsModule, MenuComponent]
+  imports: [CommonModule, FormsModule]
 })
 export class FlashcardComponent implements OnInit {
   flashcards: Flashcard[] = [];

--- a/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
+++ b/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MenuComponent } from '../menu/menu.component';
 
 @Component({
   selector: 'app-help-page',
   standalone: true,
-  imports: [CommonModule, MenuComponent],
+  imports: [CommonModule],
   templateUrl: './help-page.component.html',
   styleUrl: './help-page.component.css'
 })

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -3,14 +3,13 @@ import { Router } from '@angular/router';
 import { Deck } from '../models/deck';
 import { CommonModule } from '@angular/common';
 import { DeckService } from '../services/deck.service';
-import { MenuComponent } from '../menu/menu.component';
 import { FormsModule } from '@angular/forms';
 import { FlashcardQueryService } from '../services/flashcard-query.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, MenuComponent, FormsModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css'],
   providers: [FlashcardQueryService]

--- a/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
+++ b/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MenuComponent } from '../menu/menu.component';
 import { FormsModule } from '@angular/forms';
 import { LearningPathService } from '../services/learning-path.service';
 import { LearningPath } from '../models/LearningPath';
@@ -11,7 +10,7 @@ import { HttpClientModule } from '@angular/common/http';
 @Component({
   selector: 'app-learning-path',
   standalone: true,
-  imports: [CommonModule, FormsModule, MenuComponent, HttpClientModule],
+  imports: [CommonModule, FormsModule, HttpClientModule],
   templateUrl: './learning-path.component.html',
   styleUrl: './learning-path.component.css'
 })


### PR DESCRIPTION
## Summary
- remove `MenuComponent` imports from components that do not use it

## Testing
- `npm test --silent --if-present -- --watch=false` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858672bb148832aa43aa4a6d6d5a9c1