### PR TITLE
Set production API url

### DIFF
--- a/frontend/flashcards-ui/src/environments/environment.prod.ts
+++ b/frontend/flashcards-ui/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'http://backend:5000'
+  // In production the API runs on the host machine. Update the base URL
+  // so mobile clients can reach it using the server's IP address.
+  apiBaseUrl: 'http://10.0.0.9:5000'
 };

--- a/frontend/flashcards-ui/src/ngsw-config.json
+++ b/frontend/flashcards-ui/src/ngsw-config.json
@@ -31,8 +31,8 @@
       "urls": [
         "/decks",
         "/decks/**",
-        "http://backend:5000/decks",
-        "http://backend:5000/decks/**"
+        "http://10.0.0.9:5000/decks",
+        "http://10.0.0.9:5000/decks/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",
@@ -46,8 +46,8 @@
       "urls": [
         "/flashcards",
         "/flashcards/**",
-        "http://backend:5000/flashcards",
-        "http://backend:5000/flashcards/**"
+        "http://10.0.0.9:5000/flashcards",
+        "http://10.0.0.9:5000/flashcards/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",


### PR DESCRIPTION
## Summary
- update production API base URL to server's IP
- update service worker config accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587f9ffe30832a9e67d9c64d56e371