### PR TITLE
Add admin link in menu

### DIFF
--- a/frontend/flashcards-ui/src/app/menu/menu.component.html
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.html
@@ -15,6 +15,7 @@
       <a [routerLink]="['/']" routerLinkActive="active" (click)="closeMenu()">Home</a>
       <a [routerLink]="['/manage-flashcards']" routerLinkActive="active" (click)="closeMenu()">Manage Flashcards</a>
       <a [routerLink]="['/learning-paths']" routerLinkActive="active" (click)="closeMenu()">Learning Paths</a>
+      <a *ngIf="auth.isAdmin()" [routerLink]="['/admin/users']" routerLinkActive="active" (click)="closeMenu()">User Admin</a>
       <a [routerLink]="['/about']" routerLinkActive="active" (click)="closeMenu()">About</a>
       <a [routerLink]="['/help']" routerLinkActive="active" (click)="closeMenu()">Help</a>
     </div>


### PR DESCRIPTION
## Summary
- show *User Admin* link in the menu when the logged-in user has the `admin` role

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858874765a0832aae9edb98e294c9aa