### PR TITLE
Define role constants

### DIFF
--- a/backend/FlashcardsApi/Controllers/UsersController.cs
+++ b/backend/FlashcardsApi/Controllers/UsersController.cs
@@ -24,7 +24,7 @@ namespace FlashcardsApi.Controllers
         }
 
         [HttpGet]
-        [Authorize(Roles = "admin")]
+        [Authorize(Roles = UserRoles.Admin)]
         public ActionResult<IEnumerable<User>> GetAll() => Ok(_userService.GetAll());
 
         [HttpGet("{id}")]
@@ -37,7 +37,7 @@ namespace FlashcardsApi.Controllers
         }
 
         [HttpPost]
-        [Authorize(Roles = "admin")]
+        [Authorize(Roles = UserRoles.Admin)]
         public IActionResult Add(User user)
         {
             _userService.Add(user);
@@ -45,7 +45,7 @@ namespace FlashcardsApi.Controllers
         }
 
         [HttpPut("{id}")]
-        [Authorize(Roles = "admin")]
+        [Authorize(Roles = UserRoles.Admin)]
         public IActionResult Update(string id, User user)
         {
             if (id != user.Id) return BadRequest();
@@ -54,7 +54,7 @@ namespace FlashcardsApi.Controllers
         }
 
         [HttpDelete("{id}")]
-        [Authorize(Roles = "admin")]
+        [Authorize(Roles = UserRoles.Admin)]
         public IActionResult Delete(string id)
         {
             _userService.Delete(id);

--- a/backend/FlashcardsApi/Models/UserRoles.cs
+++ b/backend/FlashcardsApi/Models/UserRoles.cs
@@ -1,0 +1,8 @@
+namespace FlashcardsApi.Models
+{
+    public static class UserRoles
+    {
+        public const string Admin = "admin";
+        public const string User = "user";
+    }
+}

--- a/backend/FlashcardsApi/Services/UserService.cs
+++ b/backend/FlashcardsApi/Services/UserService.cs
@@ -20,7 +20,7 @@ namespace FlashcardsApi.Services
                     Id = Guid.NewGuid().ToString(),
                     Username = "admin",
                     PasswordHash = HashPassword("admin123"),
-                    Roles = new List<string> { "admin" }
+                    Roles = new List<string> { UserRoles.Admin }
                 };
                 _users.Add(admin);
             }

--- a/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
@@ -5,6 +5,7 @@ import { AuthService } from '../services/auth.service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { User } from '../models/user';
+import { UserRole } from '../models/user-role';
 
 @Component({
   selector: 'app-user-admin',
@@ -14,11 +15,11 @@ import { User } from '../models/user';
 })
 export class UserAdminComponent implements OnInit {
   users: User[] = [];
-  newUser: Partial<User> = { username: '', roles: ['user'], settings: { fontSize: 'medium' } };
+  newUser: Partial<User> = { username: '', roles: [UserRole.User], settings: { fontSize: 'medium' } };
   newUserFontSize = 'medium';
-  newUserRole = 'user';
+  newUserRole: UserRole = UserRole.User;
   editingUser: User | null = null;
-  editingUserRole = 'user';
+  editingUserRole: UserRole = UserRole.User;
   editingUserFontSize = 'medium';
   error = '';
   loading = false;
@@ -41,9 +42,9 @@ export class UserAdminComponent implements OnInit {
     this.newUser.roles = [this.newUserRole];
     this.http.post(`${environment.apiBaseUrl}/users`, this.newUser).subscribe({
       next: () => {
-        this.newUser = { username: '', roles: ['user'], settings: { fontSize: 'medium' } };
+        this.newUser = { username: '', roles: [UserRole.User], settings: { fontSize: 'medium' } };
         this.newUserFontSize = 'medium';
-        this.newUserRole = 'user';
+        this.newUserRole = UserRole.User;
         this.loadUsers();
       },
       error: () => this.error = 'Failed to add user.'
@@ -52,7 +53,7 @@ export class UserAdminComponent implements OnInit {
 
   edit(user: User) {
     this.editingUser = { ...user };
-    this.editingUserRole = user.roles[0] || 'user';
+    this.editingUserRole = user.roles[0] || UserRole.User;
     this.editingUserFontSize = user.settings?.fontSize || 'medium';
   }
 
@@ -63,7 +64,7 @@ export class UserAdminComponent implements OnInit {
     this.http.put(`${environment.apiBaseUrl}/users/${this.editingUser.id}`, this.editingUser).subscribe({
       next: () => {
         this.editingUser = null;
-        this.editingUserRole = 'user';
+        this.editingUserRole = UserRole.User;
         this.loadUsers();
       },
       error: () => this.error = 'Failed to update user.'

--- a/frontend/flashcards-ui/src/app/models/user-role.ts
+++ b/frontend/flashcards-ui/src/app/models/user-role.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+  Admin = 'admin',
+  User = 'user'
+}

--- a/frontend/flashcards-ui/src/app/models/user.ts
+++ b/frontend/flashcards-ui/src/app/models/user.ts
@@ -2,9 +2,11 @@ export interface UserSettings {
   fontSize?: string;
 }
 
+import { UserRole } from './user-role';
+
 export interface User {
   id: string;
   username: string;
-  roles: string[];
+  roles: UserRole[];
   settings: UserSettings;
 }

--- a/frontend/flashcards-ui/src/app/services/auth.service.ts
+++ b/frontend/flashcards-ui/src/app/services/auth.service.ts
@@ -3,18 +3,14 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
+import { User } from '../models/user';
+import { UserRole } from '../models/user-role';
 
 export interface LoginRequest {
   username: string;
   password: string;
 }
 
-export interface User {
-  id: string;
-  username: string;
-  roles: string[];
-  settings: any;
-}
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -57,7 +53,7 @@ export class AuthService {
 
   isAdmin(): boolean {
     const user = this.getCurrentUser();
-    return user?.roles.includes('admin') ?? false;
+    return user?.roles.includes(UserRole.Admin) ?? false;
   }
 
   setUser(user: User | null) {


### PR DESCRIPTION
## Summary
- add `UserRoles` string constants for the API
- use `UserRoles.Admin` everywhere backend checks for admin role
- introduce `UserRole` enum in the Angular app
- update services and components to rely on the new enum

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588d7f3978832ab75532a1d3b8f537