### PR TITLE
Add user creation request type

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ docker-compose up
 ### API Docs (Swagger)
 Visit [http://localhost:5000/swagger](http://localhost:5000/swagger)
 
+### 🔐 Authentication
+The backend secures admin routes using JWT tokens. Log in with the seeded
+`admin` user to obtain a token. Include an `Authorization: Bearer <token>`
+header when calling protected endpoints. See
+[docs/api-authentication.md](docs/api-authentication.md) for detailed steps,
+including how to create additional users.
+
 ---
 
 ## ⚙️ Environment Setup

--- a/backend/FlashcardsApi/Controllers/UsersController.cs
+++ b/backend/FlashcardsApi/Controllers/UsersController.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System;
+using System.Linq;
 
 namespace FlashcardsApi.Controllers
 {
@@ -38,10 +40,18 @@ namespace FlashcardsApi.Controllers
 
         [HttpPost]
         [Authorize(Roles = UserRoles.Admin)]
-        public IActionResult Add(User user)
+        public IActionResult Add([FromBody] AddUserRequest req)
         {
+            var user = new User
+            {
+                Id = Guid.NewGuid().ToString(),
+                Username = req.Username,
+                PasswordHash = UserService.HashPassword(req.Password),
+                Roles = req.Roles?.ToList() ?? new List<string> { UserRoles.User },
+                Settings = new UserSettings()
+            };
             _userService.Add(user);
-            return Ok();
+            return Ok(new { user.Id, user.Username, user.Roles });
         }
 
         [HttpPut("{id}")]
@@ -115,5 +125,12 @@ namespace FlashcardsApi.Controllers
     {
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
+    }
+
+    public class AddUserRequest
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public IEnumerable<string>? Roles { get; set; }
     }
 }

--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -1,0 +1,53 @@
+# API Authentication
+
+The API uses JSON Web Tokens (JWT) for protected routes such as `/users`.
+
+## Login
+
+Obtain a token with the seeded admin credentials:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:5000/users/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"admin123"}' | jq -r '.token')
+```
+
+## Use the token
+
+Include the token in the `Authorization` header for subsequent requests:
+
+```bash
+curl -X GET http://localhost:5000/users \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Tokens are valid for 60 minutes by default. You can export the variable to reuse it:
+
+```bash
+export FLASHCARDS_JWT=$TOKEN
+```
+
+To persist the token across shell sessions, save it and reload when needed:
+
+```bash
+echo $TOKEN > ~/.flashcards-jwt
+export FLASHCARDS_JWT=$(cat ~/.flashcards-jwt)
+curl -X GET http://localhost:5000/users \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer $FLASHCARDS_JWT"
+```
+
+## Add a User
+
+Only admins can create new users. Send a `POST` request with `username`,
+`password` and optional `roles` fields:
+
+```bash
+curl -X POST http://localhost:5000/users \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $FLASHCARDS_JWT" \
+  -d '{"username":"bob","password":"secret","roles":["user"]}'
+```
+
+The API hashes the password and generates an ID automatically.

--- a/frontend/flashcards-ui/src/app/app.config.ts
+++ b/frontend/flashcards-ui/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 // import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { provideHttpClient, withFetch, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { provideHttpClient, withFetch, HTTP_INTERCEPTORS, withInterceptorsFromDi } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { routes } from './app.routes';
@@ -11,7 +11,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     // Hydration is only needed for SSR. Remove or comment out to avoid NG0505 warning in CSR-only builds.
     // provideClientHydration(withEventReplay()),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideRouter(routes),
     provideServiceWorker('ngsw-worker.js'),
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },


### PR DESCRIPTION
## Summary
- allow POST `/users` to accept username/password instead of requiring an Id
- document how to create users in the authentication guide
- reference the guide from the README

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet test backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685916073d68832a820b202620feb5d6