### PR TITLE
Add password input on admin page

### DIFF
--- a/frontend/flashcards-ui/src/app/admin/user-admin.component.html
+++ b/frontend/flashcards-ui/src/app/admin/user-admin.component.html
@@ -24,14 +24,15 @@
   </table>
   <div class="add-user">
     <h3>Add User</h3>
-    <input [(ngModel)]="newUser.username" placeholder="Username" />
+    <input [(ngModel)]="newUser.username" placeholder="Username" maxlength="20" />
+    <input [(ngModel)]="newUserPassword" type="password" placeholder="Password" maxlength="20" />
     <input [(ngModel)]="newUserFontSize" placeholder="Font Size" />
     <input [(ngModel)]="newUserRole" placeholder="Role (user/admin)" />
     <button (click)="addUser()">Add</button>
   </div>
   <div *ngIf="editingUser" class="edit-user">
     <h3>Edit User</h3>
-    <input [(ngModel)]="editingUser.username" placeholder="Username" />
+    <input [(ngModel)]="editingUser.username" placeholder="Username" maxlength="20" />
     <input [(ngModel)]="editingUserFontSize" placeholder="Font Size" />
     <input [(ngModel)]="editingUserRole" placeholder="Role (user/admin)" />
     <button (click)="saveEdit()">Save</button>

--- a/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
@@ -6,6 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { User } from '../models/user';
 import { UserRole } from '../models/user-role';
+import { AddUserRequest } from '../models/add-user-request';
 
 @Component({
   selector: 'app-user-admin',
@@ -16,6 +17,7 @@ import { UserRole } from '../models/user-role';
 export class UserAdminComponent implements OnInit {
   users: User[] = [];
   newUser: Partial<User> = { username: '', roles: [UserRole.User], settings: { fontSize: 'medium' } };
+  newUserPassword = '';
   newUserFontSize = 'medium';
   newUserRole: UserRole = UserRole.User;
   editingUser: User | null = null;
@@ -46,12 +48,16 @@ export class UserAdminComponent implements OnInit {
 
   addUser() {
     console.log('Adding user:', this.newUser);
-    this.newUser.settings = { fontSize: this.newUserFontSize };
-    this.newUser.roles = [this.newUserRole];
-    this.http.post(`${environment.apiBaseUrl}/users`, this.newUser).subscribe({
+    const req: AddUserRequest = {
+      username: this.newUser.username ?? '',
+      password: this.newUserPassword,
+      roles: [this.newUserRole]
+    };
+    this.http.post(`${environment.apiBaseUrl}/users`, req).subscribe({
       next: () => {
         console.log('User added successfully');
         this.newUser = { username: '', roles: [UserRole.User], settings: { fontSize: 'medium' } };
+        this.newUserPassword = '';
         this.newUserFontSize = 'medium';
         this.newUserRole = UserRole.User;
         this.loadUsers();

--- a/frontend/flashcards-ui/src/app/models/add-user-request.ts
+++ b/frontend/flashcards-ui/src/app/models/add-user-request.ts
@@ -1,0 +1,5 @@
+export interface AddUserRequest {
+  username: string;
+  password: string;
+  roles: string[];
+}


### PR DESCRIPTION
## Summary
- add `AddUserRequest` model for the UI
- update admin page to include password when creating a user
- limit username and password to 20 characters

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592603564c832a9fb31ce0f839be17