### PR TITLE
Fix user font size mapping

### DIFF
--- a/frontend/flashcards-ui/src/app/models/user.ts
+++ b/frontend/flashcards-ui/src/app/models/user.ts
@@ -1,5 +1,6 @@
 export interface UserSettings {
   fontSize?: string;
+  flashcardFontSize?: number;
 }
 
 import { UserRole } from './user-role';

--- a/frontend/flashcards-ui/src/app/services/auth.service.ts
+++ b/frontend/flashcards-ui/src/app/services/auth.service.ts
@@ -18,10 +18,21 @@ export class AuthService {
   private userSubject = new BehaviorSubject<User | null>(null);
   user$ = this.userSubject.asObservable();
 
+  private numberToFontSize(num: number | undefined): string {
+    if (num === undefined || num === null) return 'medium';
+    if (num <= 14) return 'small';
+    if (num >= 22) return 'large';
+    return 'medium';
+  }
+
   constructor(private http: HttpClient) {
     const user = localStorage.getItem('user');
     if (user) {
-      this.userSubject.next(JSON.parse(user));
+      const parsed: User = JSON.parse(user);
+      if (parsed.settings && (parsed.settings as any).flashcardFontSize !== undefined) {
+        parsed.settings.fontSize = this.numberToFontSize((parsed.settings as any).flashcardFontSize);
+      }
+      this.userSubject.next(parsed);
     }
   }
 
@@ -30,6 +41,9 @@ export class AuthService {
       tap(res => {
         if (res.token) {
           localStorage.setItem(this.tokenKey, res.token);
+          if (res.user && res.user.settings) {
+            res.user.settings.fontSize = this.numberToFontSize(res.user.settings.flashcardFontSize);
+          }
           localStorage.setItem('user', JSON.stringify(res.user));
           this.userSubject.next(res.user);
         }
@@ -60,3 +74,4 @@ export class AuthService {
     this.userSubject.next(user);
   }
 }
+

--- a/frontend/flashcards-ui/src/app/user/user-settings.component.ts
+++ b/frontend/flashcards-ui/src/app/user/user-settings.component.ts
@@ -18,14 +18,36 @@ export class UserSettingsComponent {
   message = '';
   error = '';
 
+  private numberToFontSize(num: number | undefined): string {
+    if (num === undefined || num === null) return 'medium';
+    if (num <= 14) return 'small';
+    if (num >= 22) return 'large';
+    return 'medium';
+  }
+
+  private fontSizeToNumber(size: string): number {
+    switch (size) {
+      case 'small':
+        return 14;
+      case 'large':
+        return 24;
+      default:
+        return 18;
+    }
+  }
+
   constructor(private auth: AuthService, private http: HttpClient) {
     this.user = this.auth.getCurrentUser();
-    this.fontSize = this.user?.settings?.fontSize || 'medium';
+    const num = this.user?.settings?.flashcardFontSize;
+    this.fontSize = this.user?.settings?.fontSize || this.numberToFontSize(num);
   }
 
   save() {
     if (!this.user) return;
-    const settings: UserSettings = { fontSize: this.fontSize };
+    const settings: UserSettings = {
+      flashcardFontSize: this.fontSizeToNumber(this.fontSize),
+      fontSize: this.fontSize
+    };
     const updated: User = {
       id: this.user.id,
       username: this.user.username,


### PR DESCRIPTION
## Summary
- map backend font size to UI
- convert font size numbers to strings
- store updated settings in auth service
- preserve password when editing users

## Testing
- `npm test` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685927dc25cc832a87b5d0baa218076d