### PR TITLE
Handle missing PointId import

### DIFF
--- a/python_backend/app/services/qdrant_flashcard_service.py
+++ b/python_backend/app/services/qdrant_flashcard_service.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from typing import List, Iterable, Tuple
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import PointStruct, PointId, VectorParams, Distance, Filter, FieldCondition, HasIdCondition
+from qdrant_client.http.models import PointStruct, VectorParams, Distance, Filter, FieldCondition, HasIdCondition
+try:
+    from qdrant_client.http.models import PointId
+except ImportError:  # Older or newer qdrant-client versions may not expose PointId
+    PointId = str  # type: ignore
 from ..models import Flashcard, Deck
 import uuid
 import os

--- a/python_backend/app/services/qdrant_learning_path_service.py
+++ b/python_backend/app/services/qdrant_learning_path_service.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 from typing import List, Iterable, Tuple, Optional
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import PointStruct, PointId, VectorParams, Distance, Filter, FieldCondition, HasIdCondition
+from qdrant_client.http.models import PointStruct, VectorParams, Distance, Filter, FieldCondition, HasIdCondition
+try:
+    from qdrant_client.http.models import PointId
+except ImportError:  # Older or newer qdrant-client versions may not expose PointId
+    PointId = str  # type: ignore
 from ..models import LearningPath
 import uuid
 import os


### PR DESCRIPTION
## Summary
- prevent crash if `PointId` is missing in qdrant client

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68592f45f990832a8cbf76af874e4232