### PR TITLE
Fix Qdrant client configuration

### DIFF
--- a/python_backend/app/services/qdrant_flashcard_service.py
+++ b/python_backend/app/services/qdrant_flashcard_service.py
@@ -14,7 +14,11 @@ import json
 
 class QdrantFlashcardService:
     def __init__(self, host: str = "10.0.0.9", port: int = 6334, collection: str = "flashcards", vector_size: int = 384):
-        self.client = QdrantClient(host=host, port=port)
+        # `qdrant-client` expects REST port in the `port` argument and gRPC port
+        # in `grpc_port`.  Our environment variables provide the gRPC port (6334
+        # by default) so we configure the client accordingly and explicitly
+        # prefer gRPC.
+        self.client = QdrantClient(host=host, grpc_port=port, prefer_grpc=True)
         self.collection = collection
         self.vector_size = vector_size
         self._ensure_collection()

--- a/python_backend/app/services/qdrant_learning_path_service.py
+++ b/python_backend/app/services/qdrant_learning_path_service.py
@@ -14,7 +14,9 @@ import json
 
 class QdrantLearningPathService:
     def __init__(self, host: str = "10.0.0.9", port: int = 6334, collection: str = "learning_paths", vector_size: int = 64):
-        self.client = QdrantClient(host=host, port=port)
+        # The provided port corresponds to the gRPC interface.  Configure the
+        # client to use it instead of the REST API.
+        self.client = QdrantClient(host=host, grpc_port=port, prefer_grpc=True)
         self.collection = collection
         self.vector_size = vector_size
         self._ensure_collection()


### PR DESCRIPTION
## Summary
- fix python backend to connect to gRPC port of Qdrant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685933870ff4832a874cf6f0598e8db0