### PR TITLE
Fix pydantic alias handling

### DIFF
--- a/python_backend/app/models.py
+++ b/python_backend/app/models.py
@@ -1,8 +1,13 @@
 from typing import List, Optional
 from pydantic import BaseModel, Field
+try:
+    from pydantic import ConfigDict  # Pydantic v2
+except ImportError:  # pragma: no cover - compatibility for Pydantic v1
+    ConfigDict = dict  # type: ignore
 import uuid
 
 class Flashcard(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     question: str = ""
     answer: str = ""
@@ -15,6 +20,7 @@ class Flashcard(BaseModel):
         allow_population_by_field_name = True
 
 class Deck(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     description: str = ""
 
@@ -22,6 +28,7 @@ class Deck(BaseModel):
         allow_population_by_field_name = True
 
 class LearningPath(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str = ""
     description: str = ""
@@ -32,12 +39,14 @@ class LearningPath(BaseModel):
         allow_population_by_field_name = True
 
 class UserSettings(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     flashcard_font_size: int = Field(18, alias="flashcardFontSize")
 
     class Config:
         allow_population_by_field_name = True
 
 class User(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     username: str
     password_hash: str = Field(alias="passwordHash")


### PR DESCRIPTION
## Summary
- ensure models allow field name population with Pydantic v2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593c68c7a0832ab051b89089ab829b