### PR TITLE
Fix pydantic config for compatibility

### DIFF
--- a/python_backend/app/models.py
+++ b/python_backend/app/models.py
@@ -1,13 +1,16 @@
 from typing import List, Optional
 from pydantic import BaseModel, Field
+import pydantic
+
 try:
-    from pydantic import ConfigDict  # Pydantic v2
-except ImportError:  # pragma: no cover - compatibility for Pydantic v1
+    from pydantic import ConfigDict  # Available in Pydantic v1 and v2
+except ImportError:  # pragma: no cover - compatibility for very old versions
     ConfigDict = dict  # type: ignore
+
+PYDANTIC_V2 = pydantic.version.VERSION.startswith("2")
 import uuid
 
 class Flashcard(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     question: str = ""
     answer: str = ""
@@ -16,42 +19,53 @@ class Flashcard(BaseModel):
     explanation: str = ""
     topic: str = ""
 
-    class Config:
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True
 
 class Deck(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     description: str = ""
 
-    class Config:
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True
 
 class LearningPath(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str = ""
     description: str = ""
     card_ids: Optional[List[str]] = Field(default=None, alias="cardIds")
     topics: Optional[List[str]] = None
 
-    class Config:
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True
 
 class UserSettings(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
     flashcard_font_size: int = Field(18, alias="flashcardFontSize")
 
-    class Config:
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True
 
 class User(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     username: str
     password_hash: str = Field(alias="passwordHash")
     roles: List[str] = Field(default_factory=lambda: ["user"])
     settings: UserSettings = Field(default_factory=UserSettings)
 
-    class Config:
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True


### PR DESCRIPTION
## Summary
- detect pydantic version reliably
- only use `model_config` in v2 and `Config` in v1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593d619c18832aafa8f6ae9f9c98fb