### PR TITLE
Add approve-all option in bulk import

### DIFF
--- a/backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj
+++ b/backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/backend/FlashcardsApi.Tests/IntegrationTests.cs
+++ b/backend/FlashcardsApi.Tests/IntegrationTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using FlashcardsApi.Models;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var settings = new Dictionary<string, string>
+            {
+                {"Storage:Provider", "InMemory"},
+                {"OpenAI:ApiKey", "test-key"}
+            };
+            config.AddInMemoryCollection(settings);
+        });
+    }
+}
+
+public class IntegrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public IntegrationTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PostFlashcardAndRetrieve()
+    {
+        var card = new Flashcard { Question = "Q1", Answer = "A1", DeckId = "deck" };
+        var response = await _client.PostAsJsonAsync("/flashcards", card);
+        response.EnsureSuccessStatusCode();
+
+        var getAll = await _client.GetAsync("/flashcards");
+        getAll.EnsureSuccessStatusCode();
+        var cards = await getAll.Content.ReadFromJsonAsync<List<Flashcard>>();
+        Assert.Single(cards);
+        Assert.Equal("Q1", cards[0].Question);
+    }
+
+    [Fact]
+    public async Task AddLearningPathAndRetrieve()
+    {
+        var path = new LearningPath { Id = "1", Name = "Path", Description = "Desc", CardIds = new List<string>() };
+        var resp = await _client.PostAsJsonAsync("/api/learning-paths", path);
+        resp.EnsureSuccessStatusCode();
+
+        var get = await _client.GetAsync("/api/learning-paths");
+        get.EnsureSuccessStatusCode();
+        var paths = await get.Content.ReadFromJsonAsync<List<LearningPath>>();
+        Assert.Single(paths);
+        Assert.Equal("Path", paths[0].Name);
+    }
+}

--- a/backend/FlashcardsApi/Program.cs
+++ b/backend/FlashcardsApi/Program.cs
@@ -147,3 +147,6 @@ public class OpenAiConfig
 {
     public string ApiKey { get; set; } = string.Empty;
 }
+
+public partial class Program { }
+

--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
@@ -7,6 +7,9 @@
   <button class="btn btn-outline-primary mb-3" (click)="exportFlashcards()">Export Flashcards as JSON</button>
   <div *ngIf="importedFlashcards.length > 0">
     <h4>Preview Imported Flashcards</h4>
+    <label class="form-check-label d-block mb-2">
+      <input type="checkbox" class="form-check-input me-1" [(ngModel)]="approveAll" (change)="toggleApproveAll()"> Approve All
+    </label>
     <div *ngFor="let card of importedFlashcards; let i = index" class="card mb-3 p-3 border">
       <div *ngIf="editingIndex !== i; else editCardBlock">
         <div><strong>Question:</strong> {{ card['question'] || card['Question'] }}</div>
@@ -16,7 +19,7 @@
         <div><strong>Topic:</strong> {{ card['topic'] || card['Topic'] }}</div>
         <div class="mt-2">
           <label class="me-2">
-            <input type="checkbox" [(ngModel)]="approvedFlashcards[i]"> Approve
+            <input type="checkbox" [(ngModel)]="approvedFlashcards[i]" (change)="updateApproveAll()"> Approve
           </label>
           <button class="btn btn-sm btn-outline-primary" (click)="editCard(i)">Edit</button>
         </div>

--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
@@ -17,6 +17,7 @@ export class FlashcardBulkImportComponent {
   loading = false;
   importedFlashcards: any[] = [];
   approvedFlashcards: boolean[] = [];
+  approveAll = false;
   editingIndex: number | null = null;
   editedCard: any = null;
 
@@ -32,6 +33,7 @@ export class FlashcardBulkImportComponent {
           if (Array.isArray(json)) {
             this.importedFlashcards = json;
             this.approvedFlashcards = new Array(json.length).fill(false);
+            this.approveAll = false;
             this.uploadResult = '';
           } else {
             this.uploadResult = 'JSON must be an array of flashcards.';
@@ -46,6 +48,7 @@ export class FlashcardBulkImportComponent {
 
   approveCard(idx: number) {
     this.approvedFlashcards[idx] = true;
+    this.updateApproveAll();
   }
 
   editCard(idx: number) {
@@ -64,6 +67,14 @@ export class FlashcardBulkImportComponent {
     this.editedCard = null;
   }
 
+  toggleApproveAll() {
+    this.approvedFlashcards = this.approvedFlashcards.map(() => this.approveAll);
+  }
+
+  updateApproveAll() {
+    this.approveAll = this.approvedFlashcards.length > 0 && this.approvedFlashcards.every(v => v);
+  }
+
   saveAll() {
     const toSave = this.importedFlashcards.filter((_, idx) => this.approvedFlashcards[idx]);
     if (toSave.length === 0) {
@@ -78,6 +89,7 @@ export class FlashcardBulkImportComponent {
         this.loading = false;
         this.importedFlashcards = [];
         this.approvedFlashcards = [];
+        this.approveAll = false;
       },
       error: (err) => {
         this.uploadResult = 'Import failed: ' + (err.error?.message || err.message || 'Unknown error');


### PR DESCRIPTION
## Summary
- add integration tests that boot the API with in-memory services
- expose Program class for test host
- add WebApplicationFactory dependencies
- add checkbox to approve all flashcards when importing

## Testing
- `npm test --silent` *(fails: ng not found)*
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593e527908832abe3252bafadbe346