### PR TITLE
Fix qdrant import for UUID objects

### DIFF
--- a/python_backend/app/models.py
+++ b/python_backend/app/models.py
@@ -20,8 +20,18 @@ class Flashcard(BaseModel):
     topic: str = ""
 
     if PYDANTIC_V2:
+        @pydantic.field_validator("id", mode="before")  # type: ignore[attr-defined]
+        def _normalize_id(cls, v):
+            if isinstance(v, dict) and "uuid" in v:
+                return str(v["uuid"])
+            return str(v)
         model_config = ConfigDict(populate_by_name=True)
     else:  # pragma: no cover - compatibility for Pydantic v1
+        @pydantic.validator("id", pre=True, allow_reuse=True)  # type: ignore[attr-defined]
+        def _normalize_id(cls, v):
+            if isinstance(v, dict) and "uuid" in v:
+                return str(v["uuid"])
+            return str(v)
         class Config:
             allow_population_by_field_name = True
 


### PR DESCRIPTION
## Summary
- normalize `Flashcard.id` when given as `{ "uuid": "..." }`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685945cec404832aabc94bb081242bbb