### PR TITLE
Move save-all button in bulk import view

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.html
@@ -7,9 +7,12 @@
   <button class="btn btn-outline-primary mb-3" (click)="exportFlashcards()">Export Flashcards as JSON</button>
   <div *ngIf="importedFlashcards.length > 0">
     <h4>Preview Imported Flashcards</h4>
-    <label class="form-check-label d-block mb-2">
-      <input type="checkbox" class="form-check-input me-1" [(ngModel)]="approveAll" (change)="toggleApproveAll()"> Approve All
-    </label>
+    <div class="d-flex align-items-center mb-2">
+      <label class="form-check-label mb-0 me-3">
+        <input type="checkbox" class="form-check-input me-1" [(ngModel)]="approveAll" (change)="toggleApproveAll()"> Approve All
+      </label>
+      <button class="btn btn-primary mt-0 ms-auto" (click)="saveAll()" [disabled]="loading">Save All Approved</button>
+    </div>
     <div *ngFor="let card of importedFlashcards; let i = index" class="card mb-3 p-3 border">
       <div *ngIf="editingIndex !== i; else editCardBlock">
         <div><strong>Question:</strong> {{ card['question'] || card['Question'] }}</div>
@@ -38,7 +41,6 @@
         </div>
       </ng-template>
     </div>
-    <button class="btn btn-primary mt-3" (click)="saveAll()" [disabled]="loading">Save All Approved</button>
   </div>
   </div>
 </div>

--- a/python_backend/app/services/qdrant_flashcard_service.py
+++ b/python_backend/app/services/qdrant_flashcard_service.py
@@ -31,6 +31,8 @@ class QdrantFlashcardService:
     def index_flashcard(self, card: Flashcard):
         if not card.id:
             card.id = str(uuid.uuid4())
+        elif isinstance(card.id, dict) and "uuid" in card.id:
+            card.id = str(card.id["uuid"])
         vector = [0.0] * self.vector_size
         # Qdrant expects the point id to be a plain string or integer. When
         # importing data previously exported from Qdrant the ``id`` field may


### PR DESCRIPTION
## Summary
- move Save All Approved button next to Approve All checkbox on the bulk import screen
- ensure string IDs when indexing flashcards

## Testing
- `pytest python_backend/tests -q`
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685948753600832a9939b50bb09e76f6