### PR TITLE
Fix dict IDs in Qdrant services

### DIFF
--- a/python_backend/app/models.py
+++ b/python_backend/app/models.py
@@ -53,8 +53,18 @@ class LearningPath(BaseModel):
     topics: Optional[List[str]] = None
 
     if PYDANTIC_V2:
+        @pydantic.field_validator("id", mode="before")  # type: ignore[attr-defined]
+        def _normalize_id(cls, v):
+            if isinstance(v, dict) and "uuid" in v:
+                return str(v["uuid"])
+            return str(v)
         model_config = ConfigDict(populate_by_name=True)
     else:  # pragma: no cover - compatibility for Pydantic v1
+        @pydantic.validator("id", pre=True, allow_reuse=True)  # type: ignore[attr-defined]
+        def _normalize_id(cls, v):
+            if isinstance(v, dict) and "uuid" in v:
+                return str(v["uuid"])
+            return str(v)
         class Config:
             allow_population_by_field_name = True
 

--- a/python_backend/app/services/qdrant_learning_path_service.py
+++ b/python_backend/app/services/qdrant_learning_path_service.py
@@ -29,8 +29,11 @@ class QdrantLearningPathService:
     def add(self, path: LearningPath):
         if not path.id:
             path.id = str(uuid.uuid4())
+        elif isinstance(path.id, dict) and "uuid" in path.id:
+            path.id = str(path.id["uuid"])
         vector = [0.0] * self.vector_size
-        point = PointStruct(id=path.id, vector=vector, payload={"json": path.json()})
+        # Ensure the point id is a simple string before sending it to Qdrant.
+        point = PointStruct(id=str(path.id), vector=vector, payload={"json": path.json()})
         self.client.upsert(collection_name=self.collection, points=[point])
 
     def update(self, path: LearningPath):

--- a/python_backend/tests/test_main.py
+++ b/python_backend/tests/test_main.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import uuid
 from python_backend.app import main, routes
 from python_backend.app.models import Flashcard, LearningPath
 from python_backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
@@ -62,4 +63,9 @@ def test_main_endpoints(monkeypatch, tmp_path):
     data = [Flashcard(question="q", answer="a")]
     assert asyncio.run(routes.bulk_import(data)) == {"message": f"Imported {len(data)} flashcards"}
     assert isinstance(asyncio.run(routes.bulk_export()), list)
+
+    uid = str(uuid.uuid4())
+    data = [Flashcard(id={"uuid": uid}, question="q2", answer="a2")]
+    assert asyncio.run(routes.bulk_import(data)) == {"message": f"Imported {len(data)} flashcards"}
+    assert any(c.id == uid for c in asyncio.run(routes.get_flashcards()))
 

--- a/python_backend/tests/test_qdrant_flashcard_service.py
+++ b/python_backend/tests/test_qdrant_flashcard_service.py
@@ -2,6 +2,7 @@ import json
 import os
 from python_backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
 from python_backend.app.models import Flashcard
+import uuid
 
 
 def test_flashcard_service(tmp_path):
@@ -32,3 +33,12 @@ def test_flashcard_service(tmp_path):
     assert success and "1 flashcards" in msg
 
     assert svc.seed_from_json("missing.json")[0] is False
+
+def test_flashcard_service_accepts_dict_id(tmp_path):
+    svc = QdrantFlashcardService(collection="test_dict")
+    uid = str(uuid.uuid4())
+    card = Flashcard(id={"uuid": uid}, question="q", answer="a")
+    svc.index_flashcard(card)
+    retrieved = svc.get_all()[0]
+    assert retrieved.id == uid
+    svc.delete(uid)

--- a/python_backend/tests/test_qdrant_learning_path_service.py
+++ b/python_backend/tests/test_qdrant_learning_path_service.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from python_backend.app.services.qdrant_learning_path_service import QdrantLearningPathService
 from python_backend.app.models import LearningPath
 
@@ -20,3 +21,11 @@ def test_learning_path_service(tmp_path):
     assert success and "1 learning paths" in msg
 
     assert svc.seed_from_json("missing.json")[0] is False
+
+def test_learning_path_service_accepts_dict_id(tmp_path):
+    svc = QdrantLearningPathService(collection="paths2")
+    uid = str(uuid.uuid4())
+    lp = LearningPath(id={"uuid": uid}, name="p")
+    svc.add(lp)
+    assert svc.get_by_id(uid).id == uid
+    svc.delete(uid)


### PR DESCRIPTION
## Summary
- normalize dict IDs for learning paths when adding
- add validation logic for LearningPath model
- test dict ID behaviour in flashcard service, learning path service, and main API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594b2090f0832a96ad37c803d31e13