### PR TITLE
Fix case sensitivity for Python flashcards endpoints

### DIFF
--- a/python_backend/app/routes.py
+++ b/python_backend/app/routes.py
@@ -45,9 +45,19 @@ async def get_random(count: int = 10):
     return main.flashcard_service.get_random(count)
 
 
+@router.get("/flashcards/random", response_model=List[Flashcard], include_in_schema=False)
+async def get_random_lower(count: int = 10):
+    return await get_random(count)
+
+
 @router.get("/Flashcards/{deckId}/random", response_model=List[Flashcard])
 async def get_random_by_deck(deckId: str, count: int = 10):
     return main.flashcard_service.get_random_by_deck(deckId, count)
+
+
+@router.get("/flashcards/{deckId}/random", response_model=List[Flashcard], include_in_schema=False)
+async def get_random_by_deck_lower(deckId: str, count: int = 10):
+    return await get_random_by_deck(deckId, count)
 
 
 @router.get("/decks", response_model=List[Deck])


### PR DESCRIPTION
## Summary
- add lowercase versions of random flashcard routes to FastAPI backend

## Testing
- `pytest -q`
- `npm test --prefix frontend/flashcards-ui` *(fails: ng not found)*
- `dotnet test backend/FlashcardsApi.Tests/FlashcardsApi.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594fba70b4832a89e0ef5238fb8b04