### PR TITLE
Fix Qdrant collection recreation

### DIFF
--- a/python_backend/app/services/qdrant_flashcard_service.py
+++ b/python_backend/app/services/qdrant_flashcard_service.py
@@ -24,9 +24,13 @@ class QdrantFlashcardService:
         self._ensure_collection()
 
     def _ensure_collection(self):
-        if self.collection not in self.client.get_collections().collections:
-            self.client.recreate_collection(collection_name=self.collection,
-                                             vectors_config=VectorParams(size=self.vector_size, distance=Distance.COSINE))
+        existing = self.client.get_collections().collections
+        names = [c.name for c in existing]
+        if self.collection not in names:
+            self.client.create_collection(
+                collection_name=self.collection,
+                vectors_config=VectorParams(size=self.vector_size,
+                                             distance=Distance.COSINE))
 
     def index_flashcard(self, card: Flashcard):
         if not card.id:

--- a/python_backend/app/services/qdrant_learning_path_service.py
+++ b/python_backend/app/services/qdrant_learning_path_service.py
@@ -22,9 +22,13 @@ class QdrantLearningPathService:
         self._ensure_collection()
 
     def _ensure_collection(self):
-        if self.collection not in self.client.get_collections().collections:
-            self.client.recreate_collection(collection_name=self.collection,
-                                             vectors_config=VectorParams(size=self.vector_size, distance=Distance.COSINE))
+        existing = self.client.get_collections().collections
+        names = [c.name for c in existing]
+        if self.collection not in names:
+            self.client.create_collection(
+                collection_name=self.collection,
+                vectors_config=VectorParams(size=self.vector_size,
+                                             distance=Distance.COSINE))
 
     def add(self, path: LearningPath):
         if not path.id:

--- a/qdrant_client/__init__.py
+++ b/qdrant_client/__init__.py
@@ -17,6 +17,11 @@ class QdrantClient:
         self.collections.add(collection_name)
         self.storage[collection_name] = []
 
+    def create_collection(self, collection_name, vectors_config):
+        if collection_name not in self.collections:
+            self.collections.add(collection_name)
+            self.storage.setdefault(collection_name, [])
+
     def upsert(self, collection_name, points):
         self.storage.setdefault(collection_name, [])
         for p in points:


### PR DESCRIPTION
## Summary
- ensure Qdrant collections are created only if missing
- add `create_collection` helper to the stubbed client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685952da0a0c832aaa65f2c1b5dd6e57