### PR TITLE
Handle wrong jwt package

### DIFF
--- a/python_backend/app/routes.py
+++ b/python_backend/app/routes.py
@@ -5,7 +5,9 @@ import os
 from datetime import datetime, timedelta
 try:
     import jwt  # Provided by PyJWT
-except ImportError:  # Fallback to bundled stub when dependency missing
+    if not hasattr(jwt, "encode"):
+        raise ImportError
+except ImportError:  # Fallback to bundled stub when dependency missing or wrong package
     import importlib.util
     import pathlib
 


### PR DESCRIPTION
## Summary
- ensure that fallback jwt stub is used when the installed `jwt` module lacks `encode`

## Testing
- `python -m pytest -q python_backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859b127b5f4832aa88e66932fef33ae