### PR TITLE
Fix FastAPI user creation

### DIFF
--- a/python_backend/app/models.py
+++ b/python_backend/app/models.py
@@ -118,3 +118,17 @@ class User(BaseModel):
     else:  # pragma: no cover - compatibility for Pydantic v1
         class Config:
             allow_population_by_field_name = True
+
+
+class AddUserRequest(BaseModel):
+    """Request model for creating a new user."""
+
+    username: str
+    password: str
+    roles: Optional[List[str]] = Field(default_factory=lambda: ["user"])
+
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover - compatibility for Pydantic v1
+        class Config:
+            allow_population_by_field_name = True

--- a/python_backend/app/routes.py
+++ b/python_backend/app/routes.py
@@ -16,7 +16,14 @@ except ImportError:  # Fallback to bundled stub when dependency missing or wrong
     jwt = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(jwt)
 
-from .models import Flashcard, Deck, LearningPath, User, UserSettings
+from .models import (
+    Flashcard,
+    Deck,
+    LearningPath,
+    User,
+    UserSettings,
+    AddUserRequest,
+)
 from . import main
 
 router = APIRouter()
@@ -213,7 +220,13 @@ async def get_users():
 
 
 @router.post("/users", response_model=User)
-async def add_user(user: User):
+async def add_user(req: AddUserRequest):
+    """Create a new user from a plain password request."""
+    user = User(
+        username=req.username,
+        password_hash=main.user_service.hash_password(req.password),
+        roles=req.roles or ["user"],
+    )
     main.user_service.add(user)
     return user
 


### PR DESCRIPTION
## Summary
- add `AddUserRequest` model for user creation
- hash password inside Python `/users` POST route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b2320290832abd521a34a8cadab5