### PR TITLE
Fix Pipfile.lock fingerprint mismatch

### DIFF
--- a/python_backend/Pipfile.lock
+++ b/python_backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "47ffb78ec7c85d978b6f359d13b2534f295f41d25cd51e14417b1205059955e7"
+            "sha256": "a1fcb32333a90ca03cde68e4be7348d4299b751308d70fa9ca0a5fad953ab098"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## Summary
- update `python_backend` lock file so `pipenv install --deploy` works

## Testing
- `pytest -q python_backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859b6c7d498832aaaf7653cf0069965