### PR TITLE
Fix Qdrant index to use embeddings

### DIFF
--- a/python_backend/tests/test_main.py
+++ b/python_backend/tests/test_main.py
@@ -5,6 +5,7 @@ from python_backend.app import main, routes
 from python_backend.app.models import Flashcard, LearningPath
 from python_backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
 from python_backend.app.services.qdrant_learning_path_service import QdrantLearningPathService
+import python_backend.app.services.qdrant_flashcard_service as flashcard_module
 from python_backend.app.services.user_service import UserService
 from python_backend.app.services import embedding
 
@@ -21,6 +22,11 @@ def setup_app(monkeypatch, tmp_path):
 
     monkeypatch.setattr(embedding, "get_embedding", dummy_emb)
     monkeypatch.setattr(main, "get_embedding", dummy_emb)
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * fc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
     return fc, lp, users
 
 

--- a/python_backend/tests/test_qdrant_flashcard_service.py
+++ b/python_backend/tests/test_qdrant_flashcard_service.py
@@ -1,12 +1,18 @@
 import json
 import os
+import uuid
+import python_backend.app.services.qdrant_flashcard_service as flashcard_module
 from python_backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
 from python_backend.app.models import Flashcard
-import uuid
 
 
-def test_flashcard_service(tmp_path):
+def test_flashcard_service(tmp_path, monkeypatch):
     svc = QdrantFlashcardService(collection="test")
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * svc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
     card = Flashcard(question="q", answer="a", deck_id="d")
     svc.index_flashcard(card)
     assert svc.get_all()[0].question == "q"
@@ -34,8 +40,13 @@ def test_flashcard_service(tmp_path):
 
     assert svc.seed_from_json("missing.json")[0] is False
 
-def test_flashcard_service_accepts_dict_id(tmp_path):
+def test_flashcard_service_accepts_dict_id(tmp_path, monkeypatch):
     svc = QdrantFlashcardService(collection="test_dict")
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * svc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
     uid = str(uuid.uuid4())
     card = Flashcard(id={"uuid": uid}, question="q", answer="a")
     svc.index_flashcard(card)


### PR DESCRIPTION
## Summary
- generate embeddings when indexing flashcards
- update tests for new embedding behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859bd9a5908832aa4d7a6e1f24557ba