### PR TITLE
Prevent duplicate flashcards

### DIFF
--- a/python_backend/tests/test_embedding.py
+++ b/python_backend/tests/test_embedding.py
@@ -15,3 +15,20 @@ def test_get_embedding(monkeypatch, tmp_path):
     emb = asyncio.run(embedding.get_embedding(" hi "))
     assert emb == [0.6, 0.8]
 
+
+
+def test_embed_array_distance(monkeypatch, tmp_path):
+    service = embedding.EmbeddingService(cache_file=str(tmp_path / "c.json"))
+
+    class DummyModel:
+        def encode(self, sentence, convert_to_numpy=True):
+            return [1, 0] if "banana" in sentence else [0, 1]
+
+    service.model = DummyModel()
+    monkeypatch.setattr(embedding, "embedding_service", service)
+
+    questions = ["apple", "banana", "cherry"]
+    vectors = service.embed_sentences(questions)
+    vec = service.embed("banana")
+    sims = [sum(a*b for a, b in zip(vec, v)) for v in vectors]
+    assert sims[1] == 1.0


### PR DESCRIPTION
## Summary
- prevent duplicate flashcards in Flashcard Admin page
- alert if new question matches existing one or if vector similarity is very high
- add test checking vector similarity of embedded questions

## Testing
- `pytest -q`
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*
- `npm test --silent` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685a39276f38832a8777f09a66980109