### PR TITLE
Modify flashcard admin filters and menu

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -2,14 +2,21 @@
     <h2>Manage Flashcards</h2>
 
     <div class="mb-3">
-        <a class="btn btn-outline-secondary" routerLink="/bulk-import">Bulk Import Flashcards</a>
-    </div>
-
-    <div class="mb-3">
-        <input class="form-control" placeholder="Filter by question" [(ngModel)]="filterText" (input)="applyFilter()" />
+        <input class="form-control" placeholder="Filter" [(ngModel)]="filterText" (input)="applyFilter()" />
     </div>
     <div class="mb-3">
-        <input class="form-control" placeholder="Filter by deck" [(ngModel)]="filterDeck" (input)="applyFilter()" />
+        <label class="form-check-label me-2">
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByQuestion" (change)="applyFilter()"> Question
+        </label>
+        <label class="form-check-label me-2">
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByDeck" (change)="applyFilter()"> Deck
+        </label>
+        <label class="form-check-label me-2">
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByTopic" (change)="applyFilter()"> Topic
+        </label>
+        <label class="form-check-label me-2">
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByEmbedding" (change)="applyFilter()"> Embedded
+        </label>
     </div>
 
     <form (ngSubmit)="saveFlashcard()" class="mb-4">

--- a/frontend/flashcards-ui/src/app/menu/menu.component.html
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.html
@@ -14,6 +14,7 @@
     <div class="nav-links" [class.open]="menuOpen">
       <a [routerLink]="['/']" routerLinkActive="active" (click)="closeMenu()">Home</a>
       <a [routerLink]="['/manage-flashcards']" routerLinkActive="active" (click)="closeMenu()">Manage Flashcards</a>
+      <a [routerLink]="['/bulk-import']" routerLinkActive="active" (click)="closeMenu()">Bulk Import</a>
       <a [routerLink]="['/learning-paths']" routerLinkActive="active" (click)="closeMenu()">Learning Paths</a>
       <a *ngIf="auth.isAdmin()" [routerLink]="['/admin/users']" routerLinkActive="active" (click)="closeMenu()">User Admin</a>
       <a [routerLink]="['/about']" routerLinkActive="active" (click)="closeMenu()">About</a>


### PR DESCRIPTION
## Summary
- consolidate manage page filters to single input with field checkboxes
- remove bulk import button from manage page
- add link to bulk import page in main menu
- add optional question embedding search filter

## Testing
- `npm test --silent` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a8f2df028832aacd6dfff99fed77b