### PR TITLE
Fix export to return JSON file

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-export.service.ts
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-export.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class FlashcardBulkExportService {
   constructor(private http: HttpClient) {}
 
   exportFlashcards() {
-    return this.http.get('/flashcardbulkexport/export-json', { responseType: 'blob' });
+    const url = `${environment.apiBaseUrl}/flashcardbulkexport/export-json`;
+    return this.http.get(url, { responseType: 'blob' });
   }
 }


### PR DESCRIPTION
## Summary
- call backend using the base API URL when exporting flashcards

## Testing
- `pytest -q`
- `npm test` *(fails: could not find '@angular-devkit/build-angular:karma' builder)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa193ed1c832a8112f735e62e4e69