### PR TITLE
Add flashcard reload action

### DIFF
--- a/frontend/flashcards-ui/src/app/help-page/help-page.component.html
+++ b/frontend/flashcards-ui/src/app/help-page/help-page.component.html
@@ -13,4 +13,8 @@
 
     <h5>🚀 Can I reset my progress?</h5>
     <p>This feature is coming soon. For now, refreshing clears temporary state.</p>
+
+    <h5>🔄 Reload Flashcards</h5>
+    <p>If your flashcards seem outdated, reload them from the database.</p>
+    <button class="btn btn-warning" (click)="reloadAll()">Reload Flashcards</button>
 </div>

--- a/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
+++ b/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FlashcardService } from '../services/flashcard.service';
 
 @Component({
   selector: 'app-help-page',
@@ -9,5 +10,13 @@ import { CommonModule } from '@angular/common';
   styleUrl: './help-page.component.css'
 })
 export class HelpPageComponent {
+  constructor(private flashcardService: FlashcardService) {}
 
+  reloadAll() {
+    this.flashcardService.reloadFromDb().subscribe({
+      next: (res) => alert(res?.message || 'Flashcards reloaded.'),
+      error: (err) =>
+        alert('Failed to reload: ' + (err.error?.message || err.message || err))
+    });
+  }
 }

--- a/frontend/flashcards-ui/src/app/services/flashcard.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard.service.ts
@@ -83,4 +83,8 @@ export class FlashcardService {
       question,
     });
   }
+
+  reloadFromDb(): Observable<any> {
+    return this.http.post(`${this.apiUrl}/seed`, {});
+  }
 }


### PR DESCRIPTION
## Summary
- add reloadFromDb() method in flashcard service
- wire a Reload Flashcards button on the help page

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_685d083de8c0832aa1f96cd0481e977b