### PR TITLE
Fix bulk import to ignore duplicates

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -70,11 +70,18 @@ def test_main_endpoints(monkeypatch, tmp_path):
     assert isinstance(login_res["token"], str)
 
     data = [Flashcard(question="q", answer="a")]
-    assert asyncio.run(routes.bulk_import(data)) == {"message": f"Imported {len(data)} flashcards"}
+    assert asyncio.run(routes.bulk_import(data)) == {"message": "Imported 1 flashcards"}
     assert isinstance(asyncio.run(routes.bulk_export()), list)
+
+    # Importing the same card again should not create a duplicate
+    assert asyncio.run(routes.bulk_import(data)) == {"message": "Imported 0 flashcards"}
+
+    # Variations with spaces or punctuation should also be ignored
+    alt = [Flashcard(question="  q!! ", answer="a")]
+    assert asyncio.run(routes.bulk_import(alt)) == {"message": "Imported 0 flashcards"}
 
     uid = str(uuid.uuid4())
     data = [Flashcard(id={"uuid": uid}, question="q2", answer="a2")]
-    assert asyncio.run(routes.bulk_import(data)) == {"message": f"Imported {len(data)} flashcards"}
+    assert asyncio.run(routes.bulk_import(data)) == {"message": "Imported 1 flashcards"}
     assert any(c.id == uid for c in asyncio.run(routes.get_flashcards()))
 


### PR DESCRIPTION
## Summary
- prevent uploading duplicate flashcards on bulk import
- update tests to cover duplicate handling
- filter spaces and punctuation when comparing flashcard questions

## Testing
- `cd backend && pipenv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d1c7fb910832a8f2a66310614e984