### PR TITLE
Improve flashcard question/answer display

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
@@ -1,0 +1,11 @@
+.answer-text {
+  background-color: #eaf7ff;
+}
+.code-answer {
+  background-color: #fffbe6;
+  font-family: 'Courier New', monospace;
+}
+.code-answer .keyword {
+  color: #d73a49;
+  font-weight: bold;
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -1,0 +1,4 @@
+<pre class="card-text answer-text" *ngIf="!isCode" (click)="onClick()">
+  {{ formatted }}
+</pre>
+<pre class="card-text code-answer" *ngIf="isCode" (click)="onClick()" [innerHTML]="formatted"></pre>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-flashcard-answer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './flashcard-answer.component.html',
+  styleUrls: ['./flashcard-answer.component.css']
+})
+export class FlashcardAnswerComponent implements OnChanges {
+  @Input() answer = '';
+  @Output() clicked = new EventEmitter<void>();
+
+  isCode = false;
+  formatted = '';
+
+  ngOnChanges() {
+    this.isCode = this.detectCode(this.answer);
+    this.formatted = this.formatAnswer(this.answer);
+  }
+
+  private detectCode(text: string): boolean {
+    return text.includes('```');
+  }
+
+  private formatAnswer(text: string): string {
+    let processed = text.replace(/(\d+\.)/g, '\n$1');
+    if (processed.startsWith('\n')) {
+      processed = processed.slice(1);
+    }
+    if (this.isCode) {
+      processed = processed.replace(/```/g, '').trim();
+      processed = this.highlightCode(processed);
+    }
+    return processed;
+  }
+
+  private highlightCode(code: string): string {
+    const escaped = code
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    const keywords = ['const', 'let', 'function', 'return', 'if', 'else', 'for', 'while'];
+    const kwRegex = new RegExp('\\b(' + keywords.join('|') + ')\\b', 'g');
+    return escaped.replace(kwRegex, '<span class="keyword">$1</span>');
+  }
+
+  onClick() {
+    this.clicked.emit();
+  }
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
@@ -28,6 +28,10 @@ pre.card-text {
   text-indent: 0;
 }
 
+.question-text {
+  background-color: #f5fff5;
+}
+
 .alert-info {
   white-space: pre-wrap;
   font-family: 'Courier New', monospace;

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
@@ -2,9 +2,8 @@
   <div class="card shadow-lg">
     <div class="card-body text-center" [ngStyle]="{'font-size': fontSize === 'large' ? '2em' : fontSize === 'small' ? '1em' : '1.3em'}">
       <h5 class="card-title mb-4">Card {{ currentIndex + 1 }} of {{ flashcards.length }}</h5>
-      <pre class="card-text display-6 text-start">
-        {{ showAnswer ? flashcards[currentIndex].answer : flashcards[currentIndex].question }}
-      </pre>
+      <pre class="card-text display-6 question-text text-start" *ngIf="!showAnswer" (click)="flip()">{{ flashcards[currentIndex].question }}</pre>
+      <app-flashcard-answer *ngIf="showAnswer" [answer]="flashcards[currentIndex].answer" (clicked)="flip()"></app-flashcard-answer>
       <div *ngIf="showExplanation" class="alert alert-info text-start mt-3">
         {{ flashcards[currentIndex].explanation }}
       </div>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
@@ -4,6 +4,7 @@ import { FlashcardService } from '../services/flashcard.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '../services/translate.pipe';
+import { FlashcardAnswerComponent } from './flashcard-answer.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
@@ -24,7 +25,7 @@ function normalizeId(id: unknown): string {
   selector: 'app-flashcard',
   templateUrl: './flashcard.component.html',
   styleUrls: ['./flashcard.component.css'],
-  imports: [CommonModule, FormsModule, TranslatePipe]
+  imports: [CommonModule, FormsModule, TranslatePipe, FlashcardAnswerComponent]
 })
 export class FlashcardComponent implements OnInit {
   flashcards: Flashcard[] = [];


### PR DESCRIPTION
## Summary
- display questions with a dedicated background
- flip cards when question or answer is clicked
- add FlashcardAnswerComponent for formatted answers and basic code highlighting

## Testing
- `pytest -q`
- `npm test --silent` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_685d7c61f06c832aa49a1e8b97c5e791