### PR TITLE
Remove delete alert from manage flashcards

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -170,8 +170,6 @@ export class FlashcardAdminComponent implements OnInit {
   }
 
   delete(card: Flashcard) {
-    if (confirm('Delete this flashcard?')) {
-      this.flashcardService.delete(card.id).subscribe(this.loadFlashcards.bind(this));
-    }
+    this.flashcardService.delete(card.id).subscribe(this.loadFlashcards.bind(this));
   }
 }


### PR DESCRIPTION
## Summary
- remove confirmation dialog from `delete` in flashcard admin component

## Testing
- `pipenv run pytest`
- `npm test --prefix frontend/flashcards-ui` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d88fa9264832abbc9c09caaf0a5ec