### PR TITLE
Align flashcard answers based on language

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -1,4 +1,15 @@
-<pre class="card-text answer-text" *ngIf="!isCode" (click)="onClick()">
+<pre
+  class="card-text answer-text"
+  *ngIf="!isCode"
+  (click)="onClick()"
+  [ngStyle]="{ 'text-align': alignment }"
+>
   {{ formatted }}
 </pre>
-<pre class="card-text code-answer" *ngIf="isCode" (click)="onClick()" [innerHTML]="formatted"></pre>
+<pre
+  class="card-text code-answer"
+  *ngIf="isCode"
+  (click)="onClick()"
+  [ngStyle]="{ 'text-align': alignment }"
+  [innerHTML]="formatted"
+></pre>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -14,10 +14,12 @@ export class FlashcardAnswerComponent implements OnChanges {
 
   isCode = false;
   formatted = '';
+  alignment: 'left' | 'right' = 'left';
 
   ngOnChanges() {
     this.isCode = this.detectCode(this.answer);
     this.formatted = this.formatAnswer(this.answer);
+    this.alignment = this.detectAlignment(this.answer);
   }
 
   private detectCode(text: string): boolean {
@@ -75,5 +77,11 @@ export class FlashcardAnswerComponent implements OnChanges {
 
   onClick() {
     this.clicked.emit();
+  }
+
+  private detectAlignment(text: string): 'left' | 'right' {
+    const hebrew = (text.match(/[\u0590-\u05FF]/g) || []).length;
+    const english = (text.match(/[A-Za-z]/g) || []).length;
+    return hebrew > english ? 'right' : 'left';
   }
 }


### PR DESCRIPTION
## Summary
- adjust FlashcardAnswer component to decide text alignment
- detect Hebrew/English ratio to set alignment

## Testing
- `npm test` *(fails: Cannot find module './compile.js')*

------
https://chatgpt.com/codex/tasks/task_e_685fe9af0b90832abdbc2916dfa3472d