### PR TITLE
Add LLM prompt env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Create a `.env.dev` file inside `backend` with your local configuration:
 QDRANT_HOST=localhost
 QDRANT_PORT=6334
 JWT_KEY=CHANGE_ME
+LLM_PROVIDER=openai
+LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."
 ```
 
 ---

--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -1,3 +1,5 @@
 QDRANT_HOST=10.0.0.9
 QDRANT_PORT=6334
 JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
+LLM_PROVIDER=openai
+LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,3 +1,5 @@
 QDRANT_HOST=qdrant
 QDRANT_PORT=6334
 JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
+LLM_PROVIDER=openai
+LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -3,8 +3,6 @@ from typing import List
 import re
 from pydantic import BaseModel
 import os
-import json
-import httpx
 from datetime import datetime, timedelta
 try:
     import jwt  # Provided by PyJWT
@@ -28,6 +26,7 @@ from .models import (
     AddUserRequest,
 )
 from . import main
+from .services.llm_service import llm_service
 
 router = APIRouter()
 
@@ -278,45 +277,9 @@ class GenerateRequest(BaseModel):
     question: str
 
 
-async def _call_chatgpt(question: str) -> dict:
-    """Call OpenAI ChatGPT API to get answer and explanation."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise HTTPException(status_code=500, detail="OpenAI API key not configured")
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-    messages = [
-        {
-            "role": "system",
-            "content": (
-                "You are a helpful assistant that answers questions for a flashcard. "
-                "Respond in JSON with 'answer' and 'explanation' fields."
-            ),
-        },
-        {"role": "user", "content": question},
-    ]
-    payload = {"model": "gpt-3.5-turbo", "messages": messages}
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            "https://api.openai.com/v1/chat/completions",
-            headers=headers,
-            json=payload,
-            timeout=30,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"].strip()
-        try:
-            return json.loads(content)
-        except Exception:
-            return {"answer": content, "explanation": ""}
-
-
 @router.post("/api/generate/flashcards", response_model=Flashcard)
 async def generate_flashcard(req: GenerateRequest):
-    result = await _call_chatgpt(req.question)
+    result = await llm_service.ask(req.question)
     answer = result.get("answer", "")
     explanation = result.get("explanation", "")
     return Flashcard(question=req.question, answer=answer, explanation=explanation)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import json
+import httpx
+from fastapi import HTTPException
+
+
+class LLMService:
+    """Service for calling different LLM providers."""
+
+    async def ask(self, question: str) -> dict:
+        """Return answer and explanation for a flashcard question."""
+        provider = os.getenv("LLM_PROVIDER", "openai").lower()
+        if provider == "deepseek":
+            return await self._call_deepseek(question)
+        return await self._call_openai(question)
+
+    def _messages(self, question: str) -> list[dict]:
+        prompt = os.getenv(
+            "LLM_SYSTEM_PROMPT",
+            "You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields.",
+        )
+        return [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": question},
+        ]
+
+    async def _call_openai(self, question: str) -> dict:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise HTTPException(status_code=500, detail="OpenAI API key not configured")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        messages = self._messages(question)
+        payload = {"model": "gpt-3.5-turbo", "messages": messages}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"].strip()
+            try:
+                return json.loads(content)
+            except Exception:
+                return {"answer": content, "explanation": ""}
+
+    async def _call_deepseek(self, question: str) -> dict:
+        api_key = os.getenv("DEEPSEEK_API_KEY")
+        if not api_key:
+            raise HTTPException(status_code=500, detail="DeepSeek API key not configured")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        messages = self._messages(question)
+        payload = {"model": "deepseek-chat", "messages": messages}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.deepseek.com/v1/chat/completions",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"].strip()
+            try:
+                return json.loads(content)
+            except Exception:
+                return {"answer": content, "explanation": ""}
+
+
+# Default service instance used by the application
+llm_service = LLMService()


### PR DESCRIPTION
## Summary
- make the system prompt configurable with `LLM_SYSTEM_PROMPT`
- reference the new variable in docs and env examples
- build LLM messages from the env var in `LLMService`

## Testing
- `pipenv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fec77fac8832ab2a72445e248b5ee