### PR TITLE
Add global loading spinner

### DIFF
--- a/frontend/flashcards-ui/src/app/app.component.html
+++ b/frontend/flashcards-ui/src/app/app.component.html
@@ -1,2 +1,3 @@
 <app-menu></app-menu>
+<app-loading-spinner></app-loading-spinner>
 <router-outlet></router-outlet>

--- a/frontend/flashcards-ui/src/app/app.component.ts
+++ b/frontend/flashcards-ui/src/app/app.component.ts
@@ -3,11 +3,12 @@ import { RouterOutlet, Router } from '@angular/router';
 import { NgIf } from '@angular/common';
 import { AuthService } from './services/auth.service';
 import { MenuComponent } from './menu/menu.component';
+import { LoadingSpinnerComponent } from './loading-spinner.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, MenuComponent],
+  imports: [RouterOutlet, MenuComponent, LoadingSpinnerComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/frontend/flashcards-ui/src/app/app.config.ts
+++ b/frontend/flashcards-ui/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { provideRouter } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { routes } from './app.routes';
 import { AuthInterceptor } from './services/auth.interceptor';
+import { LoadingInterceptor } from './services/loading.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,5 +18,6 @@ export const appConfig: ApplicationConfig = {
     // AuthInterceptor is provided here to ensure it is available for all HTTP requests
     // This is necessary for the AuthService to add the Authorization header to requests.
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
   ]
 };

--- a/frontend/flashcards-ui/src/app/loading-spinner.component.css
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.css
@@ -1,0 +1,12 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 1050;
+}

--- a/frontend/flashcards-ui/src/app/loading-spinner.component.html
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.html
@@ -1,0 +1,5 @@
+<div *ngIf="loading$ | async" class="loading-overlay">
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>

--- a/frontend/flashcards-ui/src/app/loading-spinner.component.ts
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { LoadingService } from './services/loading.service';
+
+@Component({
+  selector: 'app-loading-spinner',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './loading-spinner.component.html',
+  styleUrls: ['./loading-spinner.component.css']
+})
+export class LoadingSpinnerComponent {
+  loading$ = this.loading.loading$;
+  constructor(private loading: LoadingService) {}
+}

--- a/frontend/flashcards-ui/src/app/services/loading.interceptor.ts
+++ b/frontend/flashcards-ui/src/app/services/loading.interceptor.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingService } from './loading.service';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loading: LoadingService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    this.loading.show();
+    return next.handle(req).pipe(finalize(() => this.loading.hide()));
+  }
+}

--- a/frontend/flashcards-ui/src/app/services/loading.service.ts
+++ b/frontend/flashcards-ui/src/app/services/loading.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class LoadingService {
+  private count = 0;
+  private loadingSubject = new BehaviorSubject(false);
+  loading$ = this.loadingSubject.asObservable();
+
+  show() {
+    this.count++;
+    if (this.count === 1) {
+      this.loadingSubject.next(true);
+    }
+  }
+
+  hide() {
+    if (this.count > 0) {
+      this.count--;
+      if (this.count === 0) {
+        this.loadingSubject.next(false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- show a spinner overlay while requests are pending
- create `LoadingService` and `LoadingInterceptor`
- inject interceptor via `app.config`
- import spinner component in the root component

## Testing
- `npm test --silent` *(fails: Cannot find module './compile.js')*
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860011a926c832a8c3439f03d761b81