### PR TITLE
Fix loading spinner component initialization

### DIFF
--- a/frontend/flashcards-ui/src/app/loading-spinner.component.ts
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.ts
@@ -1,15 +1,19 @@
 import { Component } from '@angular/core';
-import { NgIf } from '@angular/common';
+import { NgIf, AsyncPipe } from '@angular/common';
+import { Observable } from 'rxjs';
 import { LoadingService } from './services/loading.service';
 
 @Component({
   selector: 'app-loading-spinner',
   standalone: true,
-  imports: [NgIf],
+  imports: [NgIf, AsyncPipe],
   templateUrl: './loading-spinner.component.html',
   styleUrls: ['./loading-spinner.component.css']
 })
 export class LoadingSpinnerComponent {
-  loading$ = this.loading.loading$;
-  constructor(private loading: LoadingService) {}
+  loading$: Observable<boolean>;
+
+  constructor(private loading: LoadingService) {
+    this.loading$ = this.loading.loading$;
+  }
 }


### PR DESCRIPTION
## Summary
- import `AsyncPipe` for the loading spinner component
- initialize `loading$` after the `LoadingService` injection

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686031745c8c832aa1f033ed0249d870