### PR TITLE
Add Ionic mobile build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ nunit-*.xml
 
 # node_modules
 node_modules/
+
+# Ionic Capacitor builds
+frontend/flashcards-ui/android/
+frontend/flashcards-ui/ios/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ npm install
 ng serve
 ```
 
+# Build mobile apps with Ionic
+
+To generate native Android and iOS projects using Capacitor run:
+
+```bash
+npm run build:mobile
+npx cap add android
+npx cap add ios
+```
+
+Launch the native IDEs with:
+
+```bash
+npm run android
+# or
+npm run ios
+```
+
+
 When accessing the app from another device, use HTTPS so the service worker can
 register and display the install icon:
 

--- a/frontend/flashcards-ui/README.md
+++ b/frontend/flashcards-ui/README.md
@@ -57,3 +57,26 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Mobile builds
+
+Use Capacitor to build Android and iOS apps. After building the Angular project run:
+
+```bash
+npm run build:mobile
+```
+
+Add platforms if not added yet:
+
+```bash
+npx cap add android
+npx cap add ios
+```
+
+Open the native IDEs:
+
+```bash
+npm run android
+# or
+npm run ios
+```

--- a/frontend/flashcards-ui/capacitor.config.ts
+++ b/frontend/flashcards-ui/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.flashcards.app',
+  appName: 'flashcards-ui',
+  webDir: 'dist/flashcards-ui/browser',
+  bundledWebRuntime: false,
+};
+
+export default config;

--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -9,7 +9,10 @@
     "test": "npx ng test --watch=false --browsers=ChromeHeadless",
     "serve:ssr:flashcards-ui": "node dist/flashcards-ui/server/server.mjs",
     "serve:prod": "npm run build && npx http-server dist/flashcards-ui/browser",
-    "serve:prod:https": "npm run build && npx http-server dist/flashcards-ui/browser -S"
+    "serve:prod:https": "npm run build && npx http-server dist/flashcards-ui/browser -S",
+    "build:mobile": "ng build && npx cap copy",
+    "android": "npm run build:mobile && npx cap open android",
+    "ios": "npm run build:mobile && npx cap open ios"
   },
   "private": true,
   "dependencies": {
@@ -28,7 +31,9 @@
     "flashcards-ui": "file:",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "@ionic/angular": "^9.0.0",
+    "@capacitor/core": "^5.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.11",
@@ -43,6 +48,10 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "@ionic/angular-toolkit": "^9.0.0",
+    "@capacitor/cli": "^5.0.0",
+    "@capacitor/android": "^5.0.0",
+    "@capacitor/ios": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Capacitor config and scripts for Android/iOS
- add Ionic/Capacitor dependencies
- ignore generated mobile folders
- document mobile build steps in READMEs

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686034e34cd0832abece3ac3101f62fa