### PR TITLE
Fix Angular build errors with Ionic imports

### DIFF
--- a/frontend/flashcards-ui/src/app/about/about.component.ts
+++ b/frontend/flashcards-ui/src/app/about/about.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '../services/translate.pipe';

--- a/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/admin/user-admin.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/frontend/flashcards-ui/src/app/app.component.ts
+++ b/frontend/flashcards-ui/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { RouterOutlet, Router } from '@angular/router';
 import { NgIf } from '@angular/common';

--- a/frontend/flashcards-ui/src/app/auth/login.component.ts
+++ b/frontend/flashcards-ui/src/app/auth/login.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '../services/translate.pipe';
 import { Component } from '@angular/core';

--- a/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard-bulk-import/flashcard-bulk-import.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, OnInit } from '@angular/core';
 import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, OnInit } from '@angular/core';
 import { Flashcard } from '../../models/flashcard';
 import { FlashcardService } from '../../services/flashcard.service';

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, OnInit } from '@angular/core';
 import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';

--- a/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
+++ b/frontend/flashcards-ui/src/app/help-page/help-page.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '../services/translate.pipe';

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { Deck } from '../models/deck';

--- a/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
+++ b/frontend/flashcards-ui/src/app/learning-path/learning-path.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/frontend/flashcards-ui/src/app/loading-spinner.component.ts
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { NgIf, AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';

--- a/frontend/flashcards-ui/src/app/menu/menu.component.ts
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';

--- a/frontend/flashcards-ui/src/app/user/user-settings.component.ts
+++ b/frontend/flashcards-ui/src/app/user/user-settings.component.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular/standalone';
+import { IonicModule } from '@ionic/angular';
 import { Component } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { HttpClient } from '@angular/common/http';


### PR DESCRIPTION
## Summary
- reference `IonicModule` from `@ionic/angular`
- keep `provideIonicAngular` from the `standalone` package

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6860424036d4832aac2fa779ca6a8076