### PR TITLE
Fix blank home page by importing Ionic CSS

### DIFF
--- a/frontend/flashcards-ui/angular.json
+++ b/frontend/flashcards-ui/angular.json
@@ -30,8 +30,7 @@
             ],
             "styles": [
               "src/styles.css",
-              "node_modules/bootstrap/dist/css/bootstrap.min.css",
-              "src/styles.css"
+              "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"

--- a/frontend/flashcards-ui/src/styles.css
+++ b/frontend/flashcards-ui/src/styles.css
@@ -1,1 +1,15 @@
-/* You can add global styles to this file, and also import other style files */
+/* Ionic core CSS required for Ionic components to work properly */
+@import "@ionic/angular/css/core.css";
+@import "@ionic/angular/css/normalize.css";
+@import "@ionic/angular/css/structure.css";
+@import "@ionic/angular/css/typography.css";
+
+/* Optional utility CSS */
+@import "@ionic/angular/css/padding.css";
+@import "@ionic/angular/css/float-elements.css";
+@import "@ionic/angular/css/text-alignment.css";
+@import "@ionic/angular/css/text-transformation.css";
+@import "@ionic/angular/css/flex-utils.css";
+@import "@ionic/angular/css/display.css";
+
+/* Additional global styles can go below */


### PR DESCRIPTION
## Summary
- include required Ionic CSS in the global stylesheet
- remove duplicate reference to styles in angular.json

## Testing
- `pipenv run pytest`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686050263058832ab12666e4c75a7e95