### PR TITLE
Add debug console logs across frontend

### DIFF
--- a/frontend/flashcards-ui/src/app/app.component.ts
+++ b/frontend/flashcards-ui/src/app/app.component.ts
@@ -19,7 +19,9 @@ export class AppComponent {
   showFallback = false;
   lastError: string | null = null;
 
-  constructor(public auth: AuthService, private router: Router) {}
+  constructor(public auth: AuthService, private router: Router) {
+    console.log('[AppComponent] constructor');
+  }
 
   get userAvatarUrl(): string {
     // You can extend this to use a user profile image if available
@@ -36,10 +38,12 @@ export class AppComponent {
 
   toggleMenu() {
     this.menuOpen = !this.menuOpen;
+    console.log('[AppComponent] toggleMenu ->', this.menuOpen);
   }
 
   closeMenu() {
     this.menuOpen = false;
+    console.log('[AppComponent] closeMenu');
   }
 
   onRouteActivate(event: any) {

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
@@ -44,10 +44,12 @@ export class FlashcardComponent implements OnInit {
   ) {
     const user = this.auth.getCurrentUser();
     this.fontSize = user?.settings?.fontSize || 'medium';
+    console.log('[FlashcardComponent] constructor fontSize', this.fontSize);
   }
 
   ngOnInit(): void {
     const deckId = this.route.snapshot.paramMap.get('deckId');
+    console.log('[FlashcardComponent] ngOnInit deckId', deckId);
     if (!deckId) {
       // Redirect or show error
       console.warn('Missing deckId!');
@@ -60,6 +62,7 @@ export class FlashcardComponent implements OnInit {
       if (tempDeckRaw) {
         try {
           const tempDeck = JSON.parse(tempDeckRaw);
+          console.log('[FlashcardComponent] loaded temp deck from sessionStorage', tempDeck);
           this.flashcards = (tempDeck.flashcards || []).map((card: any) => {
             let id: string;
             if (typeof card.id === 'string') {
@@ -76,9 +79,11 @@ export class FlashcardComponent implements OnInit {
           this.flashcards = [];
         }
       } else {
+        console.warn('[FlashcardComponent] temp deck not found in sessionStorage');
         this.flashcards = [];
       }
     } else {
+      console.log('[FlashcardComponent] loading random flashcards for deck', deckId);
       this.flashcardService.getRandom(deckId, 50).subscribe((cards: any[]) => {
         // Normalize all flashcard IDs to be strings
         this.flashcards = cards.map(card => {
@@ -99,6 +104,7 @@ export class FlashcardComponent implements OnInit {
   flip() {
     this.showAnswer = !this.showAnswer;
     this.showExplanation = false;
+    console.log('[FlashcardComponent] flip -> showAnswer', this.showAnswer);
 
   }
 
@@ -109,6 +115,7 @@ export class FlashcardComponent implements OnInit {
   }
 
   vote(up: boolean): void {
+    console.log('[FlashcardComponent] vote', up);
     const current = this.flashcards[this.currentIndex];
     const newUserScore = up ? this.userScore(current) + 1 : this.userScore(current);
 
@@ -120,9 +127,11 @@ export class FlashcardComponent implements OnInit {
     }
     // Always update the local userScore
     (current as any).userScore = newUserScore;
+    console.log('[FlashcardComponent] updated userScore', newUserScore);
 
     // Remove the current card
     this.flashcards.splice(this.currentIndex, 1);
+    console.log('[FlashcardComponent] removed current card, remaining', this.flashcards.length);
 
     if (!up) {
       const min = this.currentIndex;
@@ -131,19 +140,24 @@ export class FlashcardComponent implements OnInit {
       // Always normalize id to string for the updated card
       const updatedCard = { ...current, id: normalizedId, userScore: newUserScore };
       this.flashcards.splice(randomPos, 0, updatedCard);
+      console.log('[FlashcardComponent] reinserted card at', randomPos);
     }
 
     if (this.currentIndex >= this.flashcards.length) {
       this.currentIndex = 0;
+      console.log('[FlashcardComponent] reset currentIndex to 0');
     }
 
     this.showAnswer = false;
+    console.log('[FlashcardComponent] hiding answer after vote');
   }
 
 
   allPassed(): boolean {
     // Use userScore for pass logic
-    return this.flashcards.every(card => this.userScore(card) > 2);
+    const passed = this.flashcards.every(card => this.userScore(card) > 2);
+    console.log('[FlashcardComponent] allPassed ->', passed);
+    return passed;
   }
 
   readAloud() {
@@ -159,6 +173,7 @@ export class FlashcardComponent implements OnInit {
     }
     if (text) {
       const utterance = new window.SpeechSynthesisUtterance(text);
+      console.log('[FlashcardComponent] readAloud', text);
       window.speechSynthesis.speak(utterance);
     }
   }

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -22,6 +22,7 @@ export class HomeComponent {
   queryText: string = '';
   get filteredDecks(): Deck[] {
     const text = this.filterText.toLowerCase();
+    console.log('[HomeComponent] filtering decks with text:', text);
     return this.decks.filter(deck =>
       (deck.name || deck.id).toLowerCase().includes(text) ||
       (deck.description || '').toLowerCase().includes(text)
@@ -32,11 +33,14 @@ export class HomeComponent {
     private router: Router,
     private deckService: DeckService,
     private flashcardQueryService: FlashcardQueryService
-  ) { }
+  ) {
+    console.log('[HomeComponent] constructor');
+  }
 
 
   ngOnInit(): void {
     console.log('[HomeComponent] ngOnInit');
+    console.log('[HomeComponent] Fetching decks from service');
     this.deckService.getDecks().subscribe({
       next: (data) => {
         this.decks = data;
@@ -47,14 +51,16 @@ export class HomeComponent {
   }
 
   selectDeck(deck: Deck) {
-    console.log("select deck"+deck.id);
+    console.log('[HomeComponent] selectDeck ->', deck.id);
     this.router.navigate(['/deck', deck.id]);
   }
 
   submitQuery() {
     if (!this.queryText.trim()) return;
+    console.log('[HomeComponent] submitQuery ->', this.queryText);
     this.flashcardQueryService.queryString(this.queryText).subscribe({
       next: (result) => {
+        console.log('[HomeComponent] query result:', result);
         if (Array.isArray(result) && result.length > 0) {
           // Create a temp deck from the response
           const tempDeck = {

--- a/frontend/flashcards-ui/src/app/loading-spinner.component.ts
+++ b/frontend/flashcards-ui/src/app/loading-spinner.component.ts
@@ -16,5 +16,6 @@ export class LoadingSpinnerComponent {
 
   constructor(private loading: LoadingService) {
     this.loading$ = this.loading.loading$;
+    console.log('[LoadingSpinnerComponent] initialized');
   }
 }

--- a/frontend/flashcards-ui/src/app/services/auth.service.ts
+++ b/frontend/flashcards-ui/src/app/services/auth.service.ts
@@ -34,9 +34,11 @@ export class AuthService {
       }
       this.userSubject.next(parsed);
     }
+    console.log('[AuthService] initialized with user', this.userSubject.value);
   }
 
   login(req: LoginRequest): Observable<any> {
+    console.log('[AuthService] login', req.username);
     return this.http.post<any>(`${environment.apiBaseUrl}/users/login`, req).pipe(
       tap(res => {
         if (res.token) {
@@ -52,6 +54,7 @@ export class AuthService {
   }
 
   logout() {
+    console.log('[AuthService] logout');
     localStorage.removeItem(this.tokenKey);
     localStorage.removeItem('user');
     this.userSubject.next(null);

--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -13,6 +13,7 @@ export class DeckService {
   constructor(private http: HttpClient) {}
 
   getDecks(): Observable<Deck[]> {
+    console.log('[DeckService] GET', this.apiUrl);
     return this.http.get<Deck[]>(this.apiUrl);
   }
 }

--- a/frontend/flashcards-ui/src/app/services/flashcard-query.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard-query.service.ts
@@ -14,6 +14,8 @@ export class FlashcardQueryService {
   constructor(private http: HttpClient) {}
 
   queryString(query: string): Observable<any> {
-    return this.http.post<any>(`${API_BASE_URL}/Flashcards/query-string`, { query });
+    const url = `${API_BASE_URL}/Flashcards/query-string`;
+    console.log('[FlashcardQueryService] POST', url, { query });
+    return this.http.post<any>(url, { query });
   }
 }

--- a/frontend/flashcards-ui/src/app/services/flashcard.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard.service.ts
@@ -36,55 +36,68 @@ export class FlashcardService {
   constructor(private http: HttpClient) {}
 
   getAll(): Observable<Flashcard[]> {
+    console.log('[FlashcardService] GET all flashcards', this.apiUrl);
     return this.http.get<Flashcard[]>(this.apiUrl);
   }
 
   create(card: Flashcard): Observable<Flashcard> {
     // Always normalize id before sending
     const normalizedCard = { ...card, id: normalizeId(card.id) };
+    console.log('[FlashcardService] CREATE flashcard', normalizedCard);
     return this.http.post<Flashcard>(this.apiUrl, normalizedCard);
   }
 
   update(card: Flashcard): Observable<Flashcard> {
     const normalizedId = normalizeId(card.id);
     const normalizedCard = { ...card, id: String(normalizedId) };
-    console.log('PUT URL:', `${this.apiUrl}/${normalizedId}`);
-    console.log('PUT payload:', normalizedCard);
+    console.log('[FlashcardService] UPDATE URL:', `${this.apiUrl}/${normalizedId}`);
+    console.log('[FlashcardService] UPDATE payload:', normalizedCard);
     return this.http.put<Flashcard>(`${this.apiUrl}/${normalizedId}`, normalizedCard);
   }
 
   delete(id: string): Observable<void> {
-    return this.http.delete<void>(`${this.apiUrl}/${normalizeId(id)}`);
+    const url = `${this.apiUrl}/${normalizeId(id)}`;
+    console.log('[FlashcardService] DELETE', url);
+    return this.http.delete<void>(url);
   }
 
   getRandom(deckId: string, count = 50): Observable<Flashcard[]> {
-    return this.http.get<Flashcard[]>(`${this.apiUrl}/${deckId}/random?count=${count}`);
+    const url = `${this.apiUrl}/${deckId}/random?count=${count}`;
+    console.log('[FlashcardService] GET random flashcards', url);
+    return this.http.get<Flashcard[]>(url);
   }
 
   updateScore(id: string, score: number): Observable<void> {
     const normalizedId = normalizeId(id);
-    return this.http.patch<void>(`${this.apiUrl}/${normalizedId}/score`, score);
+    const url = `${this.apiUrl}/${normalizedId}/score`;
+    console.log('[FlashcardService] PATCH score', url, 'score=', score);
+    return this.http.patch<void>(url, score);
   }
 
   updateFlashcard(card: Flashcard): Observable<Flashcard> {
     const normalizedId = normalizeId(card.id);
     const normalizedCard = { ...card, id: String(normalizedId) };
-    console.log('PUT URL:', `${this.apiUrl}/${normalizedId}`);
-    console.log('PUT payload:', normalizedCard);
+    console.log('[FlashcardService] UPDATE flashcard URL:', `${this.apiUrl}/${normalizedId}`);
+    console.log('[FlashcardService] UPDATE flashcard payload:', normalizedCard);
     return this.http.put<Flashcard>(`${this.apiUrl}/${normalizedId}`, normalizedCard);
   }
 
   deleteFlashcard(id: string): Observable<void> {
+    console.log('[FlashcardService] deleteFlashcard', id);
     return this.delete(normalizeId(id));
   }
 
   generate(question: string): Observable<Flashcard> {
-    return this.http.post<Flashcard>(`${API_BASE_URL}/api/generate/flashcards`, {
+    const url = `${API_BASE_URL}/api/generate/flashcards`;
+    console.log('[FlashcardService] generate flashcard', url, question);
+    return this.http.post<Flashcard>(url, {
       question,
     });
   }
 
   reloadFromDb(): Observable<any> {
-    return this.http.post(`${this.apiUrl}/seed`, {});
+    const url = `${this.apiUrl}/seed`;
+    console.log('[FlashcardService] reloadFromDb', url);
+    return this.http.post(url, {});
   }
 }

--- a/frontend/flashcards-ui/src/app/services/loading.interceptor.ts
+++ b/frontend/flashcards-ui/src/app/services/loading.interceptor.ts
@@ -9,7 +9,13 @@ export class LoadingInterceptor implements HttpInterceptor {
   constructor(private loading: LoadingService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    console.log('[LoadingInterceptor] request started', req.url);
     this.loading.show();
-    return next.handle(req).pipe(finalize(() => this.loading.hide()));
+    return next
+      .handle(req)
+      .pipe(finalize(() => {
+        console.log('[LoadingInterceptor] request finished', req.url);
+        this.loading.hide();
+      }));
   }
 }

--- a/frontend/flashcards-ui/src/app/services/loading.service.ts
+++ b/frontend/flashcards-ui/src/app/services/loading.service.ts
@@ -10,6 +10,7 @@ export class LoadingService {
   show() {
     this.count++;
     if (this.count === 1) {
+      console.log('[LoadingService] show loading indicator');
       this.loadingSubject.next(true);
     }
   }
@@ -18,6 +19,7 @@ export class LoadingService {
     if (this.count > 0) {
       this.count--;
       if (this.count === 0) {
+        console.log('[LoadingService] hide loading indicator');
         this.loadingSubject.next(false);
       }
     }

--- a/frontend/flashcards-ui/src/main.ts
+++ b/frontend/flashcards-ui/src/main.ts
@@ -3,7 +3,13 @@ import { provideIonicAngular } from '@ionic/angular/standalone';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
+console.log('[main.ts] Starting application bootstrap');
+
 bootstrapApplication(AppComponent, {
   ...appConfig,
   providers: [...(appConfig.providers || []), provideIonicAngular()],
-}).catch((err) => console.error(err));
+})
+  .then((appRef) => {
+    console.log('[main.ts] Application bootstrapped successfully', appRef);
+  })
+  .catch((err) => console.error('[main.ts] Bootstrap failed', err));


### PR DESCRIPTION
## Summary
- add bootstrapping logs in `main.ts`
- add constructor and method logs in `AppComponent`
- log filtering, deck loading, and query results in `HomeComponent`
- add detailed logs in `FlashcardComponent` lifecycle and actions
- log HTTP requests in services
- log loading spinner activity

## Testing
- `npm test --prefix frontend/flashcards-ui` *(fails: 403 Forbidden when downloading `ng`)*

------
https://chatgpt.com/codex/tasks/task_e_686051cac618832ab0c73abbc4dcc781