### PR TITLE
Improve frontend logging for deck loading

### DIFF
--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -12,7 +12,7 @@
   </div>
   <div class="row mb-3">
     <div class="col-12 col-md-6 mx-auto">
-      <input type="text" class="form-control" placeholder="{{ 'FILTER_DECKS' | translate }}" [(ngModel)]="filterText">
+      <input type="text" class="form-control" placeholder="{{ 'FILTER_DECKS' | translate }}" [(ngModel)]="filterText" (ngModelChange)="onFilterChange($event)">
     </div>
   </div>
   <div class="row">

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -22,11 +22,16 @@ export class HomeComponent {
   queryText: string = '';
   get filteredDecks(): Deck[] {
     const text = this.filterText.toLowerCase();
-    console.log('[HomeComponent] filtering decks with text:', text);
-    return this.decks.filter(deck =>
+    const result = this.decks.filter(deck =>
       (deck.name || deck.id).toLowerCase().includes(text) ||
       (deck.description || '').toLowerCase().includes(text)
     );
+    console.log('[HomeComponent] filtering decks with text:', text, 'count:', result.length);
+    return result;
+  }
+
+  onFilterChange(value: string) {
+    console.log('[HomeComponent] filterText changed:', value);
   }
 
   constructor(
@@ -45,6 +50,7 @@ export class HomeComponent {
       next: (data) => {
         this.decks = data;
         console.log('[HomeComponent] Loaded decks:', data);
+        console.log('[HomeComponent] total decks loaded:', this.decks.length);
       },
       error: (err) => console.error('[HomeComponent] Failed to load decks:', err)
     });

--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Deck } from '../models/deck';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 const API_BASE_URL = environment.apiBaseUrl;
@@ -14,6 +14,8 @@ export class DeckService {
 
   getDecks(): Observable<Deck[]> {
     console.log('[DeckService] GET', this.apiUrl);
-    return this.http.get<Deck[]>(this.apiUrl);
+    return this.http.get<Deck[]>(this.apiUrl).pipe(
+      tap(decks => console.log('[DeckService] received decks:', decks))
+    );
   }
 }


### PR DESCRIPTION
## Summary
- enhance deck service with response logging
- log when deck filtering occurs and report count
- log filter text changes in the home component
- log total deck count when decks are loaded from service

## Testing
- `npm test` *(fails: cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686053660454832abc9722b188a9d010