### PR TITLE
Improve logging for deck loading

### DIFF
--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -1,5 +1,5 @@
 import { IonicModule } from '@ionic/angular';
-import { Component } from '@angular/core';
+import { Component, AfterViewInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Deck } from '../models/deck';
 import { CommonModule } from '@angular/common';
@@ -16,7 +16,7 @@ imports: [IonicModule, CommonModule, FormsModule, TranslatePipe],
   styleUrls: ['./home.component.css'],
   providers: [FlashcardQueryService]
 })
-export class HomeComponent {
+export class HomeComponent implements AfterViewInit {
   decks: Deck[] = [];
   filterText: string = '';
   queryText: string = '';
@@ -42,6 +42,11 @@ export class HomeComponent {
     console.log('[HomeComponent] constructor');
   }
 
+  ngAfterViewInit(): void {
+    const cardCount = document.querySelectorAll('.card.mb-4.shadow').length;
+    console.log('[HomeComponent] view initialized, card elements:', cardCount);
+  }
+
 
   ngOnInit(): void {
     console.log('[HomeComponent] ngOnInit');
@@ -51,6 +56,11 @@ export class HomeComponent {
         this.decks = data;
         console.log('[HomeComponent] Loaded decks:', data);
         console.log('[HomeComponent] total decks loaded:', this.decks.length);
+        if (this.decks.length === 0) {
+          console.warn('[HomeComponent] no decks returned from backend');
+        } else {
+          console.log('[HomeComponent] first deck:', this.decks[0]);
+        }
       },
       error: (err) => console.error('[HomeComponent] Failed to load decks:', err)
     });

--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -15,7 +15,10 @@ export class DeckService {
   getDecks(): Observable<Deck[]> {
     console.log('[DeckService] GET', this.apiUrl);
     return this.http.get<Deck[]>(this.apiUrl).pipe(
-      tap(decks => console.log('[DeckService] received decks:', decks))
+      tap({
+        next: decks => console.log('[DeckService] received decks:', decks),
+        error: err => console.error('[DeckService] failed to fetch decks:', err)
+      })
     );
   }
 }


### PR DESCRIPTION
## Summary
- add extra debug logging when fetching decks
- log deck card count after HomeComponent view renders

## Testing
- `pipenv run pytest`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686054ed7c44832a80938c199c2a6297