### PR TITLE
Fix missing Metro config

### DIFF
--- a/frontend/flashcards-native/metro.config.js
+++ b/frontend/flashcards-native/metro.config.js
@@ -1,0 +1,11 @@
+const {getDefaultConfig, mergeConfig} = require('metro-config');
+
+/**
+ * Metro configuration
+ * https://facebook.github.io/metro/docs/configuration
+ */
+module.exports = (async () => {
+  const defaultConfig = await getDefaultConfig(__dirname);
+  const config = {};
+  return mergeConfig(defaultConfig, config);
+})();


### PR DESCRIPTION
## Summary
- add Metro config so React Native project can start

## Testing
- `pipenv run pytest`
- `npm start` (shows Metro server starting)


------
https://chatgpt.com/codex/tasks/task_e_686065dacac4832a9e8ec4f9d047c175