### PR TITLE
Add image management and fields

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from dotenv import load_dotenv
@@ -32,3 +33,8 @@ user_service = UserService()
 from . import routes
 
 app.include_router(routes.router)
+
+# Serve uploaded images
+images_dir = os.path.join(os.path.dirname(__file__), 'resources', 'images')
+os.makedirs(images_dir, exist_ok=True)
+app.mount('/images', StaticFiles(directory=images_dir), name='images')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,6 +18,9 @@ class Flashcard(BaseModel):
     score: int = 0
     deck_id: str = Field("", alias="deckId")
     explanation: str = ""
+    question_image: str = Field("", alias="questionImage")
+    answer_image: str = Field("", alias="answerImage")
+    explanation_image: str = Field("", alias="explanationImage")
     topic: str = ""
 
     if PYDANTIC_V2:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,6 +1,8 @@
 import asyncio
 import pytest
 import uuid
+import os
+from fastapi import UploadFile
 from backend.app import main, routes
 from backend.app.models import Flashcard, LearningPath
 from backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
@@ -84,4 +86,18 @@ def test_main_endpoints(monkeypatch, tmp_path):
     data = [Flashcard(id={"uuid": uid}, question="q2", answer="a2")]
     assert asyncio.run(routes.bulk_import(data)) == {"message": "Imported 1 flashcards"}
     assert any(c.id == uid for c in asyncio.run(routes.get_flashcards()))
+
+    # Image endpoints
+    images = asyncio.run(routes.list_images())
+    assert isinstance(images, list)
+    # create a dummy file for upload
+    test_name = 'test.txt'
+    with open(test_name, 'w') as f:
+        f.write('x')
+    with open(test_name, 'rb') as f:
+        file = UploadFile(filename=test_name, file=f)
+        asyncio.run(routes.upload_images([file]))
+    assert test_name in asyncio.run(routes.list_images())
+    asyncio.run(routes.delete_image(test_name))
+    os.remove(test_name)
 

--- a/frontend/flashcards-ui/src/app/app.routes.ts
+++ b/frontend/flashcards-ui/src/app/app.routes.ts
@@ -10,11 +10,13 @@ import { LoginComponent } from './auth/login.component';
 import { UserAdminComponent } from './admin/user-admin.component';
 import { AdminGuard } from './services/auth.guard';
 import { UserSettingsComponent } from './user/user-settings.component';
+import { ImageManagerComponent } from './image-manager/image-manager.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'deck/:deckId', component: FlashcardComponent },
   { path: 'manage-flashcards', component: FlashcardAdminComponent },
+  { path: 'manage-images', component: ImageManagerComponent },
   { path: 'learning-paths', component: LearningPathComponent },
   { path: 'about', component: HelpPageComponent },
   { path: 'help', component: AboutComponent },

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin.component.ts
@@ -42,7 +42,8 @@ interface AdminFlashcard extends Flashcard {
 export class FlashcardAdminComponent implements OnInit {
   flashcards: AdminFlashcard[] = [];
   editCard: AdminFlashcard | null = null;
-  newCard: AdminFlashcard = { id: '', question: '', answer: '', score: 0, explanation: '', deckId: '', topic: '' };
+  newCard: AdminFlashcard = { id: '', question: '', answer: '', score: 0,
+    explanation: '', deckId: '', topic: '', questionImage: '', answerImage: '', explanationImage: '' };
 
   constructor(private flashcardService: FlashcardService, private router: Router) { }
 
@@ -113,7 +114,8 @@ export class FlashcardAdminComponent implements OnInit {
     const normalizedCard = { ...rest, id: normalizedId };
     this.flashcardService.create(normalizedCard as Flashcard).subscribe(() => {
       this.loadAll();
-      this.newCard = { id: '', question: '', answer: '', score: 0, explanation: '', deckId: '', topic: '' };
+      this.newCard = { id: '', question: '', answer: '', score: 0,
+        explanation: '', deckId: '', topic: '', questionImage: '', answerImage: '', explanationImage: '' };
     });
   }
 }

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -22,10 +22,22 @@
     <form (ngSubmit)="saveFlashcard()" class="mb-4">
         <input class="form-control mb-2" placeholder="Question" [(ngModel)]="newFlashcard.question" name="question"
             required />
+        <select class="form-select mb-2" [(ngModel)]="newFlashcard.questionImage" name="questionImage">
+            <option value="">(none)</option>
+            <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
+        </select>
         <textarea class="form-control mb-2" rows="3" placeholder="Answer" [(ngModel)]="newFlashcard.answer"
             name="answer" required></textarea>
+        <select class="form-select mb-2" [(ngModel)]="newFlashcard.answerImage" name="answerImage">
+            <option value="">(none)</option>
+            <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
+        </select>
         <textarea class="form-control mb-2" rows="3" placeholder="Explanation" [(ngModel)]="newFlashcard.explanation"
             name="explanation"></textarea>
+        <select class="form-select mb-2" [(ngModel)]="newFlashcard.explanationImage" name="explanationImage">
+            <option value="">(none)</option>
+            <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
+        </select>
         <input class="form-control mb-2" placeholder="Deck ID" [(ngModel)]="newFlashcard.deckId" name="deckId" />
         <input class="form-control mb-2" placeholder="Topic" [(ngModel)]="newFlashcard.topic" name="topic" />
         <button class="btn btn-primary" type="submit">{{ newFlashcard.id ? 'Update' : 'Add' }}</button>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -6,6 +6,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TranslatePipe } from '../../services/translate.pipe';
+import { ImageService } from '../../services/image.service';
 
 @Component({
   selector: 'app-flashcard-admin',
@@ -30,16 +31,20 @@ export class FlashcardAdminComponent implements OnInit {
   filterByEmbedding = false;
   sortColumn: keyof Flashcard | '' = '';
   sortDirection: 'asc' | 'desc' = 'asc';
-  newFlashcard: Flashcard = { id: '', question: '', answer: '', explanation: '', deckId: '', score: 0, topic: '' };
+  newFlashcard: Flashcard = { id: '', question: '', answer: '', explanation: '',
+    deckId: '', score: 0, topic: '', questionImage: '', answerImage: '', explanationImage: '' };
   editingCard: Flashcard | null = null;
+  availableImages: string[] = [];
 
   constructor(
     private flashcardService: FlashcardService,
-    private flashcardQueryService: FlashcardQueryService
+    private flashcardQueryService: FlashcardQueryService,
+    private imageService: ImageService
   ) {}
 
   ngOnInit(): void {
     this.loadFlashcards();
+    this.imageService.list().subscribe(list => this.availableImages = list);
   }
 
   loadFlashcards() {
@@ -143,7 +148,9 @@ export class FlashcardAdminComponent implements OnInit {
     } else {
       this.flashcardService.create(this.newFlashcard).subscribe(this.loadFlashcards.bind(this));
     }
-    this.newFlashcard = { id: '', question: '', answer: '', explanation: '', deckId: '', score: 0, topic: '' };
+    this.newFlashcard = {
+      id: '', question: '', answer: '', explanation: '', deckId: '', score: 0,
+      topic: '', questionImage: '', answerImage: '', explanationImage: '' };
   }
 
   generate() {

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.css
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.css
@@ -1,0 +1,13 @@
+.image-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.image-item {
+  width: 120px;
+  text-align: center;
+}
+.image-item img {
+  max-width: 100%;
+  height: auto;
+}

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.html
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.html
@@ -1,0 +1,16 @@
+<div class="container mt-4">
+  <h2>Manage Images</h2>
+  <div class="mb-3">
+    <input type="file" multiple (change)="onFilesSelected($event)" />
+    <button class="btn btn-danger ms-2" (click)="deleteSelected()">Delete Selected</button>
+  </div>
+  <div class="image-grid">
+    <div class="image-item" *ngFor="let img of images">
+      <img [src]="apiUrl + '/images/' + img" alt="image" />
+      <div>
+        <input type="checkbox" (change)="toggleSelect(img, $event)" />
+        <button class="btn btn-sm btn-outline-danger" (click)="delete(img)">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.ts
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ImageService } from '../services/image.service';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-image-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './image-manager.component.html',
+  styleUrls: ['./image-manager.component.css']
+})
+export class ImageManagerComponent implements OnInit {
+  images: string[] = [];
+  selected: Set<string> = new Set();
+  apiUrl = environment.apiBaseUrl;
+
+  constructor(private imageService: ImageService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load() {
+    this.imageService.list().subscribe(list => {
+      this.images = list;
+      this.selected.clear();
+    });
+  }
+
+  onFilesSelected(event: any) {
+    const files: File[] = Array.from(event.target.files || []);
+    if (files.length) {
+      this.imageService.upload(files).subscribe(() => this.load());
+    }
+    event.target.value = '';
+  }
+
+  toggleSelect(name: string, event: any) {
+    if (event.target.checked) this.selected.add(name); else this.selected.delete(name);
+  }
+
+  delete(name: string) {
+    this.imageService.delete(name).subscribe(() => this.load());
+  }
+
+  deleteSelected() {
+    if (this.selected.size === 0) return;
+    this.imageService.deleteMany(Array.from(this.selected)).subscribe(() => this.load());
+  }
+}

--- a/frontend/flashcards-ui/src/app/menu/menu.component.html
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.html
@@ -15,6 +15,7 @@
     <div class="nav-links" [class.open]="menuOpen">
       <a [routerLink]="['/']" routerLinkActive="active" (click)="closeMenu()">{{ 'HOME' | translate }}</a>
       <a [routerLink]="['/manage-flashcards']" routerLinkActive="active" (click)="closeMenu()">{{ 'MANAGE_FLASHCARDS' | translate }}</a>
+      <a [routerLink]="['/manage-images']" routerLinkActive="active" (click)="closeMenu()">{{ 'MANAGE_IMAGES' | translate }}</a>
       <a [routerLink]="['/bulk-import']" routerLinkActive="active" (click)="closeMenu()">{{ 'BULK_IMPORT' | translate }}</a>
       <a [routerLink]="['/learning-paths']" routerLinkActive="active" (click)="closeMenu()">{{ 'LEARNING_PATHS' | translate }}</a>
       <a *ngIf="auth.isAdmin()" [routerLink]="['/admin/users']" routerLinkActive="active" (click)="closeMenu()">{{ 'USER_ADMIN' | translate }}</a>

--- a/frontend/flashcards-ui/src/app/models/flashcard.ts
+++ b/frontend/flashcards-ui/src/app/models/flashcard.ts
@@ -5,5 +5,8 @@ export interface Flashcard {
     score: number;
     deckId: string;
     explanation: string;
+    questionImage?: string;
+    answerImage?: string;
+    explanationImage?: string;
     topic: string;
   }

--- a/frontend/flashcards-ui/src/app/services/image.service.ts
+++ b/frontend/flashcards-ui/src/app/services/image.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+const API_BASE_URL = environment.apiBaseUrl;
+
+@Injectable({ providedIn: 'root' })
+export class ImageService {
+  private baseUrl = `${API_BASE_URL}/images`;
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<string[]> {
+    return this.http.get<string[]>(this.baseUrl);
+  }
+
+  upload(files: File[]): Observable<any> {
+    const formData = new FormData();
+    files.forEach(f => formData.append('files', f));
+    return this.http.post(this.baseUrl + '/upload', formData);
+  }
+
+  delete(name: string): Observable<any> {
+    return this.http.delete(`${this.baseUrl}/${encodeURIComponent(name)}`);
+  }
+
+  deleteMany(names: string[]): Observable<any> {
+    return this.http.post(this.baseUrl + '/delete', { names });
+  }
+}

--- a/frontend/flashcards-ui/src/assets/i18n/en.json
+++ b/frontend/flashcards-ui/src/assets/i18n/en.json
@@ -1,6 +1,7 @@
 {
   "HOME": "Home",
   "MANAGE_FLASHCARDS": "Manage Flashcards",
+  "MANAGE_IMAGES": "Manage Images",
   "BULK_IMPORT": "Bulk Import",
   "LEARNING_PATHS": "Learning Paths",
   "USER_ADMIN": "User Admin",

--- a/frontend/flashcards-ui/src/assets/i18n/he.json
+++ b/frontend/flashcards-ui/src/assets/i18n/he.json
@@ -1,6 +1,7 @@
 {
   "HOME": "בית",
   "MANAGE_FLASHCARDS": "ניהול כרטיסיות",
+  "MANAGE_IMAGES": "ניהול תמונות",
   "BULK_IMPORT": "ייבוא מרוכז",
   "LEARNING_PATHS": "מסלולי לימוד",
   "USER_ADMIN": "ניהול משתמשים",

--- a/scripts/migrate_add_image_fields.py
+++ b/scripts/migrate_add_image_fields.py
@@ -1,0 +1,25 @@
+"""Add image fields to all flashcards in Qdrant."""
+import os
+from backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
+from backend.app.models import Flashcard
+
+QDRANT_HOST = os.getenv("QDRANT_HOST", "10.0.0.9")
+QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6334"))
+
+svc = QdrantFlashcardService(QDRANT_HOST, QDRANT_PORT)
+
+cards = svc.get_all()
+for c in cards:
+    updated = False
+    if not getattr(c, 'question_image', None):
+        c.question_image = ''
+        updated = True
+    if not getattr(c, 'answer_image', None):
+        c.answer_image = ''
+        updated = True
+    if not getattr(c, 'explanation_image', None):
+        c.explanation_image = ''
+        updated = True
+    if updated:
+        svc.update(c)
+print(f"Processed {len(cards)} flashcards.")


### PR DESCRIPTION
## Summary
- support image uploads in backend and serve from resources/images
- add new ImageManager component with upload & delete
- add question/answer/explanation image fields to flashcards
- update manage flashcards page with image fields
- include migration script for existing data
- use dropdowns to select images when editing flashcards

## Testing
- `pipenv run pytest` *(fails: python-multipart missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860eaa19388832aa580d0abee1d8606