### PR TITLE
Add image display for flashcards

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
@@ -11,3 +11,10 @@
   color: #d73a49;
   font-weight: bold;
 }
+
+.flashcard-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto 1rem auto;
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -1,11 +1,14 @@
-<pre
-  class="card-text answer-text"
-  *ngIf="!isCode"
-  (click)="onClick()"
-  [ngStyle]="{ 'text-align': alignment }"
->
-  {{ formatted }}
-</pre>
+<div class="text-center" *ngIf="!isCode">
+  <img
+    *ngIf="image"
+    [src]="apiUrl + '/images/' + image"
+    class="flashcard-image"
+    alt="answer image"
+  />
+  <pre class="card-text answer-text" (click)="onClick()" [ngStyle]="{ 'text-align': alignment }">
+    {{ formatted }}
+  </pre>
+</div>
 <pre
   class="card-text code-answer"
   *ngIf="isCode"

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-answer',
@@ -10,11 +11,13 @@ import { CommonModule } from '@angular/common';
 })
 export class FlashcardAnswerComponent implements OnChanges {
   @Input() answer = '';
+  @Input() image = '';
   @Output() clicked = new EventEmitter<void>();
 
   isCode = false;
   formatted = '';
   alignment: 'left' | 'right' = 'left';
+  apiUrl = environment.apiBaseUrl;
 
   ngOnChanges() {
     this.isCode = this.detectCode(this.answer);

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
@@ -37,3 +37,10 @@ pre.card-text {
   font-family: 'Courier New', monospace;
   font-size: 0.95rem;
 }
+
+.flashcard-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto 1rem auto;
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
@@ -2,9 +2,26 @@
   <div class="card shadow-lg">
     <div class="card-body text-center" [ngStyle]="{'font-size': fontSize === 'large' ? '2em' : fontSize === 'small' ? '1em' : '1.3em'}">
       <h5 class="card-title mb-4">Card {{ currentIndex + 1 }} of {{ flashcards.length }}</h5>
+      <img
+        *ngIf="!showAnswer && flashcards[currentIndex].questionImage"
+        [src]="apiUrl + '/images/' + flashcards[currentIndex].questionImage"
+        class="flashcard-image"
+        alt="question image"
+      />
       <pre class="card-text display-6 question-text text-start" *ngIf="!showAnswer" (click)="flip()">{{ flashcards[currentIndex].question }}</pre>
-      <app-flashcard-answer *ngIf="showAnswer" [answer]="flashcards[currentIndex].answer" (clicked)="flip()"></app-flashcard-answer>
+      <app-flashcard-answer
+        *ngIf="showAnswer"
+        [answer]="flashcards[currentIndex].answer"
+        [image]="flashcards[currentIndex].answerImage"
+        (clicked)="flip()"
+      ></app-flashcard-answer>
       <div *ngIf="showExplanation" class="alert alert-info text-start mt-3">
+        <img
+          *ngIf="flashcards[currentIndex].explanationImage"
+          [src]="apiUrl + '/images/' + flashcards[currentIndex].explanationImage"
+          class="flashcard-image"
+          alt="explanation image"
+        />
         {{ flashcards[currentIndex].explanation }}
       </div>
       <div class="d-flex justify-content-center mt-4">

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.ts
@@ -7,6 +7,7 @@ import { TranslatePipe } from '../services/translate.pipe';
 import { FlashcardAnswerComponent } from './flashcard-answer.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { environment } from '../../environments/environment';
 
 function isUuidObject(id: unknown): id is { uuid: string } {
   return (
@@ -34,6 +35,7 @@ export class FlashcardComponent implements OnInit {
   showExplanation = false;
   selectedFlashcard: Flashcard | null = null;
   fontSize = 'medium';
+  apiUrl = environment.apiBaseUrl;
 
   constructor(
     private router: Router,


### PR DESCRIPTION
## Summary
- show flashcard images on question, answer and explanation
- center images with a new `.flashcard-image` style

## Testing
- `pipenv run pytest` *(fails: python-multipart missing)*
- `npm test --silent` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6860f28922dc832a8d2b14f223a08aae