### PR TITLE
Fix preview and image binding

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.css
@@ -1,0 +1,6 @@
+
+.image-preview {
+  max-width: 120px;
+  max-height: 120px;
+  display: block;
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -26,18 +26,21 @@
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>
+        <img *ngIf="newFlashcard.questionImage" [src]="apiUrl + '/images/' + newFlashcard.questionImage" class="image-preview mb-2" alt="question preview" />
         <textarea class="form-control mb-2" rows="3" placeholder="Answer" [(ngModel)]="newFlashcard.answer"
             name="answer" required></textarea>
         <select class="form-select mb-2" [(ngModel)]="newFlashcard.answerImage" name="answerImage">
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>
+        <img *ngIf="newFlashcard.answerImage" [src]="apiUrl + '/images/' + newFlashcard.answerImage" class="image-preview mb-2" alt="answer preview" />
         <textarea class="form-control mb-2" rows="3" placeholder="Explanation" [(ngModel)]="newFlashcard.explanation"
             name="explanation"></textarea>
         <select class="form-select mb-2" [(ngModel)]="newFlashcard.explanationImage" name="explanationImage">
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>
+        <img *ngIf="newFlashcard.explanationImage" [src]="apiUrl + '/images/' + newFlashcard.explanationImage" class="image-preview mb-2" alt="explanation preview" />
         <input class="form-control mb-2" placeholder="Deck ID" [(ngModel)]="newFlashcard.deckId" name="deckId" />
         <input class="form-control mb-2" placeholder="Topic" [(ngModel)]="newFlashcard.topic" name="topic" />
         <button class="btn btn-primary" type="submit">{{ newFlashcard.id ? 'Update' : 'Add' }}</button>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -7,6 +7,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TranslatePipe } from '../../services/translate.pipe';
 import { ImageService } from '../../services/image.service';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-admin',
@@ -35,6 +36,7 @@ export class FlashcardAdminComponent implements OnInit {
     deckId: '', score: 0, topic: '', questionImage: '', answerImage: '', explanationImage: '' };
   editingCard: Flashcard | null = null;
   availableImages: string[] = [];
+  apiUrl = environment.apiBaseUrl;
 
   constructor(
     private flashcardService: FlashcardService,

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
@@ -12,7 +12,7 @@
       <app-flashcard-answer
         *ngIf="showAnswer"
         [answer]="flashcards[currentIndex].answer"
-        [image]="flashcards[currentIndex].answerImage"
+        [image]="flashcards[currentIndex].answerImage || ''"
         (clicked)="flip()"
       ></app-flashcard-answer>
       <div *ngIf="showExplanation" class="alert alert-info text-start mt-3">


### PR DESCRIPTION
## Summary
- handle optional flashcard answer image
- show preview for selected question/answer/explanation images

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*
- `pytest -q` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860f4f1e9d0832ab9f134f47ab5b709