### PR TITLE
Fix Angular environment import path

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -7,7 +7,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TranslatePipe } from '../../services/translate.pipe';
 import { ImageService } from '../../services/image.service';
-import { environment } from '../../environments/environment';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-admin',


### PR DESCRIPTION
## Summary
- fix wrong relative path in FlashcardAdmin component

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*
- `npm start` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6860f64c0f98832a8c8a0b14d2c5d504