### PR TITLE
Implement image renaming

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -346,11 +346,25 @@ class DeleteManyRequest(BaseModel):
     names: List[str]
 
 
+class RenameRequest(BaseModel):
+    oldName: str
+    newName: str
+
+
 @router.post('/images/delete')
 async def delete_images(req: DeleteManyRequest):
     for name in req.names:
         path = os.path.join(main.images_dir, name)
         if os.path.exists(path):
             os.remove(path)
+    return {'status': 'ok'}
+
+
+@router.post('/images/rename')
+async def rename_image(req: RenameRequest):
+    old_path = os.path.join(main.images_dir, req.oldName)
+    new_path = os.path.join(main.images_dir, req.newName)
+    if os.path.exists(old_path):
+        os.rename(old_path, new_path)
     return {'status': 'ok'}
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -98,6 +98,8 @@ def test_main_endpoints(monkeypatch, tmp_path):
         file = UploadFile(filename=test_name, file=f)
         asyncio.run(routes.upload_images([file]))
     assert test_name in asyncio.run(routes.list_images())
-    asyncio.run(routes.delete_image(test_name))
+    asyncio.run(routes.rename_image(routes.RenameRequest(oldName=test_name, newName='test2.txt')))
+    assert 'test2.txt' in asyncio.run(routes.list_images())
+    asyncio.run(routes.delete_image('test2.txt'))
     os.remove(test_name)
 

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.css
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.css
@@ -11,3 +11,7 @@
   max-width: 100%;
   height: auto;
 }
+.image-item input[type="text"],
+.image-item input.form-control {
+  width: 100%;
+}

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.html
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.html
@@ -6,9 +6,11 @@
   </div>
   <div class="image-grid">
     <div class="image-item" *ngFor="let img of images">
+      <input class="form-control mb-1" [(ngModel)]="renameMap[img]" />
       <img [src]="apiUrl + '/images/' + img" alt="image" />
-      <div>
+      <div class="mt-1">
         <input type="checkbox" (change)="toggleSelect(img, $event)" />
+        <button class="btn btn-sm btn-outline-primary me-1" (click)="rename(img)">Rename</button>
         <button class="btn btn-sm btn-outline-danger" (click)="delete(img)">Delete</button>
       </div>
     </div>

--- a/frontend/flashcards-ui/src/app/image-manager/image-manager.component.ts
+++ b/frontend/flashcards-ui/src/app/image-manager/image-manager.component.ts
@@ -14,6 +14,7 @@ import { environment } from '../../environments/environment';
 export class ImageManagerComponent implements OnInit {
   images: string[] = [];
   selected: Set<string> = new Set();
+  renameMap: Record<string, string> = {};
   apiUrl = environment.apiBaseUrl;
 
   constructor(private imageService: ImageService) {}
@@ -26,6 +27,8 @@ export class ImageManagerComponent implements OnInit {
     this.imageService.list().subscribe(list => {
       this.images = list;
       this.selected.clear();
+      this.renameMap = {};
+      this.images.forEach(i => this.renameMap[i] = i);
     });
   }
 
@@ -48,5 +51,11 @@ export class ImageManagerComponent implements OnInit {
   deleteSelected() {
     if (this.selected.size === 0) return;
     this.imageService.deleteMany(Array.from(this.selected)).subscribe(() => this.load());
+  }
+
+  rename(oldName: string) {
+    const newName = (this.renameMap[oldName] || '').trim();
+    if (!newName || newName === oldName) return;
+    this.imageService.rename(oldName, newName).subscribe(() => this.load());
   }
 }

--- a/frontend/flashcards-ui/src/app/services/image.service.ts
+++ b/frontend/flashcards-ui/src/app/services/image.service.ts
@@ -27,4 +27,8 @@ export class ImageService {
   deleteMany(names: string[]): Observable<any> {
     return this.http.post(this.baseUrl + '/delete', { names });
   }
+
+  rename(oldName: string, newName: string): Observable<any> {
+    return this.http.post(this.baseUrl + '/rename', { oldName, newName });
+  }
 }


### PR DESCRIPTION
## Summary
- allow renaming uploaded images in the UI
- expose backend API to rename images
- add client service wrapper and UI controls
- test image rename in backend tests

## Testing
- `pytest -q` *(fails: python-multipart missing)*
- `npm test --prefix frontend/flashcards-ui` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_6860f7dd6748832aa3dedc22164bffdf