### PR TITLE
Fix npm install failure

### DIFF
--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -32,7 +32,7 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0",
-    "@ionic/angular": "^9.0.0",
+    "@ionic/angular": "^8.0.0",
     "@capacitor/core": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix ionic dependency version to resolve `npm install`

## Testing
- `pipenv run pytest` *(fails: python-multipart missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860fd1a29f4832a9f09b9bab7d14413