### PR TITLE
Add deck index in qdrant

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 
 from .services.qdrant_flashcard_service import QdrantFlashcardService
+from .services.qdrant_deck_service import QdrantDeckService
 from .services.qdrant_learning_path_service import QdrantLearningPathService
 from .services.user_service import UserService
 from .services.embedding import get_embedding
@@ -26,7 +27,8 @@ app.add_middleware(
 QDRANT_HOST = os.getenv("QDRANT_HOST", "10.0.0.9")
 QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6334"))
 
-flashcard_service = QdrantFlashcardService(QDRANT_HOST, QDRANT_PORT)
+deck_service = QdrantDeckService(QDRANT_HOST, QDRANT_PORT)
+flashcard_service = QdrantFlashcardService(QDRANT_HOST, QDRANT_PORT, deck_service=deck_service)
 learning_path_service = QdrantLearningPathService(QDRANT_HOST, QDRANT_PORT)
 user_service = UserService()
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -117,7 +117,7 @@ async def get_random_by_deck_lower(deckId: str, count: int = 10):
 
 @router.get("/decks", response_model=List[Deck])
 async def get_decks():
-    return main.flashcard_service.get_all_decks()
+    return main.deck_service.get_all()
 
 
 @router.post("/Flashcards/query-vector", response_model=List[Flashcard])

--- a/backend/app/services/qdrant_deck_service.py
+++ b/backend/app/services/qdrant_deck_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from typing import List
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import (
+    PointStruct,
+    VectorParams,
+    Distance,
+    Filter,
+    HasIdCondition,
+)
+try:
+    from qdrant_client.http.models import PointId
+except ImportError:  # pragma: no cover
+    PointId = str  # type: ignore
+import json
+from ..models import Deck, Flashcard
+
+
+class QdrantDeckService:
+    def __init__(
+        self,
+        host: str = "10.0.0.9",
+        port: int = 6334,
+        collection: str = "decks",
+        vector_size: int = 1,
+    ):
+        self.client = QdrantClient(host=host, grpc_port=port, prefer_grpc=True)
+        self.collection = collection
+        self.vector_size = vector_size
+        self._ensure_collection()
+
+    def _ensure_collection(self):
+        existing = self.client.get_collections().collections
+        names = [c.name for c in existing]
+        if self.collection not in names:
+            self.client.create_collection(
+                collection_name=self.collection,
+                vectors_config=VectorParams(size=self.vector_size, distance=Distance.COSINE),
+            )
+
+    def rebuild_from_flashcards(self, cards: List[Flashcard]):
+        counts = {}
+        for c in cards:
+            if c.deck_id:
+                counts.setdefault(c.deck_id, 0)
+                counts[c.deck_id] += 1
+
+        # Remove decks not present anymore
+        existing, _ = self.client.scroll(collection_name=self.collection, limit=1000)
+        existing_ids = {p.id for p in existing}
+        to_remove = existing_ids - counts.keys()
+        for deck_id in to_remove:
+            flt = Filter(must=[HasIdCondition(has_id=[PointId(str(deck_id))])])
+            self.client.delete(collection_name=self.collection, points_selector=flt)
+
+        for deck_id, count in counts.items():
+            deck = Deck(id=deck_id, description=f"Deck '{deck_id}' ({count} cards)")
+            vector = [0.0] * self.vector_size
+            payload = {"json": deck.json(), "count": count}
+            point = PointStruct(id=str(deck.id), vector=vector, payload=payload)
+            self.client.upsert(collection_name=self.collection, points=[point])
+
+    def get_all(self) -> List[Deck]:
+        points, _ = self.client.scroll(collection_name=self.collection, limit=1000)
+        decks: List[Deck] = []
+        for p in points:
+            if p.payload and "json" in p.payload:
+                data = json.loads(p.payload["json"])
+                decks.append(Deck(**data))
+        return decks

--- a/backend/tests/test_qdrant_deck_service.py
+++ b/backend/tests/test_qdrant_deck_service.py
@@ -1,0 +1,41 @@
+import backend.app.services.qdrant_flashcard_service as flashcard_module
+from backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
+from backend.app.services.qdrant_deck_service import QdrantDeckService
+from backend.app.models import Flashcard
+
+
+def test_deck_index_updates(monkeypatch):
+    deck_svc = QdrantDeckService(collection="deck_test")
+    fc_svc = QdrantFlashcardService(collection="deck_cards", deck_service=deck_svc)
+
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * fc_svc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
+
+    card = Flashcard(question="q", answer="a", deck_id="d")
+    fc_svc.index_flashcard(card)
+    decks = deck_svc.get_all()
+    assert len(decks) == 1 and decks[0].id == "d"
+
+    fc_svc.delete(card.id)
+    assert deck_svc.get_all() == []
+
+
+def test_deck_index_on_update(monkeypatch):
+    deck_svc = QdrantDeckService(collection="deck_update")
+    fc_svc = QdrantFlashcardService(collection="deck_cards2", deck_service=deck_svc)
+
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * fc_svc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
+
+    card = Flashcard(question="q", answer="a", deck_id="d")
+    fc_svc.index_flashcard(card)
+    card.deck_id = "e"
+    fc_svc.update(card)
+    ids = [d.id for d in deck_svc.get_all()]
+    assert "e" in ids and "d" not in ids


### PR DESCRIPTION
## Summary
- add `QdrantDeckService` for dedicated deck collection
- update flashcard service to keep deck index in sync
- load the new service in `main.py`
- fetch decks via new service in routes
- test deck indexing

## Testing
- `pipenv run pytest -q` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_686110d48420832aabb438f6cbbda901