### PR TITLE
Fix OpenAI key configuration

### DIFF
--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -3,3 +3,4 @@ QDRANT_PORT=6334
 JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
 LLM_PROVIDER=openai
 LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."
+OPENAI_API_KEY=sk-your-openai-api-key

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -3,3 +3,4 @@ QDRANT_PORT=6334
 JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
 LLM_PROVIDER=openai
 LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."
+OPENAI_API_KEY=sk-your-openai-api-key


### PR DESCRIPTION
## Summary
- add `OPENAI_API_KEY` to backend environment files

## Testing
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686161fd94bc832aba9a763ce576c35b