### PR TITLE
Fix home link color and improve generation

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -324,10 +324,11 @@ class GenerateRequest(BaseModel):
 
 @router.post("/api/generate/flashcards", response_model=Flashcard)
 async def generate_flashcard(req: GenerateRequest):
+    transformed = await llm_service.transform_question(req.question)
     result = await llm_service.ask(req.question)
     answer = result.get("answer", "")
     explanation = result.get("explanation", "")
-    return Flashcard(question=req.question, answer=answer, explanation=explanation)
+    return Flashcard(question=transformed, answer=answer, explanation=explanation)
 
 
 @router.post("/FlashcardBulkImport/upload-json")

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -25,21 +25,24 @@
     <form (ngSubmit)="saveFlashcard()" class="mb-4">
         <input class="form-control mb-2" placeholder="Question" [(ngModel)]="newFlashcard.question" name="question"
             required />
-        <select class="form-select mb-2" [(ngModel)]="newFlashcard.questionImage" name="questionImage">
+        <label for="questionImageSelect" class="form-label">Question Image</label>
+        <select id="questionImageSelect" class="form-select mb-2" [(ngModel)]="newFlashcard.questionImage" name="questionImage">
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>
         <img *ngIf="newFlashcard.questionImage" [src]="apiUrl + '/images/' + newFlashcard.questionImage" class="image-preview mb-2" alt="question preview" />
         <textarea class="form-control mb-2" rows="3" placeholder="Answer" [(ngModel)]="newFlashcard.answer"
             name="answer" required></textarea>
-        <select class="form-select mb-2" [(ngModel)]="newFlashcard.answerImage" name="answerImage">
+        <label for="answerImageSelect" class="form-label">Answer Image</label>
+        <select id="answerImageSelect" class="form-select mb-2" [(ngModel)]="newFlashcard.answerImage" name="answerImage">
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>
         <img *ngIf="newFlashcard.answerImage" [src]="apiUrl + '/images/' + newFlashcard.answerImage" class="image-preview mb-2" alt="answer preview" />
         <textarea class="form-control mb-2" rows="3" placeholder="Explanation" [(ngModel)]="newFlashcard.explanation"
             name="explanation"></textarea>
-        <select class="form-select mb-2" [(ngModel)]="newFlashcard.explanationImage" name="explanationImage">
+        <label for="explanationImageSelect" class="form-label">Explanation Image</label>
+        <select id="explanationImageSelect" class="form-select mb-2" [(ngModel)]="newFlashcard.explanationImage" name="explanationImage">
             <option value="">(none)</option>
             <option *ngFor="let img of availableImages" [value]="img">{{ img }}</option>
         </select>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -161,6 +161,9 @@ export class FlashcardAdminComponent implements OnInit {
       return;
     }
     this.flashcardService.generate(question).subscribe(res => {
+      if (res.question) {
+        this.newFlashcard.question = res.question;
+      }
       if (res.answer) {
         this.newFlashcard.answer = this.newFlashcard.answer
           ? this.newFlashcard.answer + '\n' + res.answer

--- a/frontend/flashcards-ui/src/app/menu/menu.component.html
+++ b/frontend/flashcards-ui/src/app/menu/menu.component.html
@@ -13,7 +13,7 @@
       </svg>
     </button>
     <div class="nav-links" [class.open]="menuOpen">
-      <a [routerLink]="['/']" routerLinkActive="active" (click)="closeMenu()">{{ 'HOME' | translate }}</a>
+      <a [routerLink]="['/']" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" (click)="closeMenu()">{{ 'HOME' | translate }}</a>
       <a [routerLink]="['/manage-flashcards']" routerLinkActive="active" (click)="closeMenu()">{{ 'MANAGE_FLASHCARDS' | translate }}</a>
       <a [routerLink]="['/manage-images']" routerLinkActive="active" (click)="closeMenu()">{{ 'MANAGE_IMAGES' | translate }}</a>
       <a [routerLink]="['/bulk-import']" routerLinkActive="active" (click)="closeMenu()">{{ 'BULK_IMPORT' | translate }}</a>


### PR DESCRIPTION
## Summary
- avoid always-highlighted Home link
- show labels for image selectors in flashcard admin page
- transform questions using LLM before returning generated flashcard
- update UI to use transformed question

## Testing
- `pytest -q`
- `npm test --silent` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6864d2cae278832abb05d6f38fd7df8e