### PR TITLE
Add deck coverage estimation

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,6 +56,7 @@ class Flashcard(BaseModel):
 class Deck(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     description: str = ""
+    coverage: float = 0.0
 
     if PYDANTIC_V2:
         model_config = ConfigDict(populate_by_name=True)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -4,6 +4,7 @@ import os
 import json
 import httpx
 from fastapi import HTTPException
+from typing import List
 
 
 class LLMService:
@@ -75,6 +76,46 @@ class LLMService:
                 return json.loads(content)
             except Exception:
                 return {"answer": content, "explanation": ""}
+
+    def _chat_sync(self, messages: List[dict]) -> str:
+        provider = os.getenv("LLM_PROVIDER", "openai").lower()
+        if provider == "deepseek":
+            api_key = os.getenv("DEEPSEEK_API_KEY")
+            if not api_key:
+                raise HTTPException(status_code=500, detail="DeepSeek API key not configured")
+            url = "https://api.deepseek.com/v1/chat/completions"
+            model = "deepseek-chat"
+            key = api_key
+        else:
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise HTTPException(status_code=500, detail="OpenAI API key not configured")
+            url = "https://api.openai.com/v1/chat/completions"
+            model = "gpt-3.5-turbo"
+            key = api_key
+        headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+        payload = {"model": model, "messages": messages}
+        resp = httpx.post(url, headers=headers, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+
+    def coverage(self, subject: str, questions: List[str]) -> float:
+        """Return estimated coverage percentage for ``subject``."""
+        prompt = (
+            f"Estimate the coverage in percent of the subject '{subject}' represented by the following questions. "
+            "Respond in JSON with a 'coverage' field containing the percentage as a number."
+        )
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "\n".join(questions)},
+        ]
+        try:
+            content = self._chat_sync(messages)
+            data = json.loads(content)
+            return float(data.get("coverage", 0.0))
+        except Exception:
+            return 0.0
 
 
 # Default service instance used by the application

--- a/backend/app/services/qdrant_flashcard_service.py
+++ b/backend/app/services/qdrant_flashcard_service.py
@@ -172,7 +172,7 @@ class QdrantFlashcardService:
             decks.setdefault(c.deck_id, 0)
             decks[c.deck_id] += 1
         return [
-            Deck(id=k, description=f"Deck '{k}' ({v} cards)") for k, v in decks.items()
+            Deck(id=k, description=f"Deck '{k}' ({v} cards)", coverage=0.0) for k, v in decks.items()
         ]
 
     def query_by_vector(self, vector: List[float], count: int = 10) -> List[Flashcard]:

--- a/backend/tests/test_qdrant_deck_service.py
+++ b/backend/tests/test_qdrant_deck_service.py
@@ -1,10 +1,17 @@
 import backend.app.services.qdrant_flashcard_service as flashcard_module
+import backend.app.services.qdrant_deck_service as deck_module
 from backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
 from backend.app.services.qdrant_deck_service import QdrantDeckService
 from backend.app.models import Flashcard
 
 
 def test_deck_index_updates(monkeypatch):
+    class DummyLLM:
+        def coverage(self, subject, questions):
+            return 50.0
+
+    monkeypatch.setattr(deck_module, "llm_service", DummyLLM())
+
     deck_svc = QdrantDeckService(collection="deck_test")
     fc_svc = QdrantFlashcardService(collection="deck_cards", deck_service=deck_svc)
 
@@ -17,13 +24,19 @@ def test_deck_index_updates(monkeypatch):
     card = Flashcard(question="q", answer="a", deck_id="d")
     fc_svc.index_flashcard(card)
     decks = deck_svc.get_all()
-    assert len(decks) == 1 and decks[0].id == "d"
+    assert len(decks) == 1 and decks[0].id == "d" and decks[0].coverage == 50.0
 
     fc_svc.delete(card.id)
     assert deck_svc.get_all() == []
 
 
 def test_deck_index_on_update(monkeypatch):
+    class DummyLLM:
+        def coverage(self, subject, questions):
+            return 60.0
+
+    monkeypatch.setattr(deck_module, "llm_service", DummyLLM())
+
     deck_svc = QdrantDeckService(collection="deck_update")
     fc_svc = QdrantFlashcardService(collection="deck_cards2", deck_service=deck_svc)
 
@@ -38,4 +51,6 @@ def test_deck_index_on_update(monkeypatch):
     card.deck_id = "e"
     fc_svc.update(card)
     ids = [d.id for d in deck_svc.get_all()]
-    assert "e" in ids and "d" not in ids
+    decks = deck_svc.get_all()
+    ids = [d.id for d in decks]
+    assert "e" in ids and "d" not in ids and all(d.coverage == 60.0 for d in decks)


### PR DESCRIPTION
## Summary
- augment Deck model with a `coverage` field
- implement coverage calculation via LLM service
- store coverage in deck records when rebuilding from flashcards
- expose coverage in fallback deck listing
- test deck coverage handling

## Testing
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e81607ac832a9fc7d186e5bfb30c