### PR TITLE
Enhance deck coverage and admin filtering

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -154,6 +154,15 @@ async def get_decks():
     return decks
 
 
+@router.post("/decks/{deck_id}/coverage")
+async def refresh_deck_coverage(deck_id: str):
+    cards = [c for c in main.flashcard_service.get_all() if c.deck_id == deck_id]
+    questions = [c.question for c in cards]
+    coverage = llm_service.coverage(deck_id, questions)
+    main.deck_service.update_coverage(deck_id, coverage, len(cards))
+    return {"coverage": coverage}
+
+
 @router.post("/Flashcards/query-vector", response_model=List[Flashcard])
 async def query_vector(vector: List[float] = Body(...), count: int = 10):
     return main.flashcard_service.query_by_vector(vector, count)

--- a/backend/app/services/qdrant_deck_service.py
+++ b/backend/app/services/qdrant_deck_service.py
@@ -96,3 +96,11 @@ class QdrantDeckService:
                 data = json.loads(p.payload["json"])
                 decks.append(Deck(**data))
         return decks
+
+    def update_coverage(self, deck_id: str, coverage: float, count: int):
+        deck = Deck(id=deck_id, description=f"Deck '{deck_id}' ({count} cards)", coverage=coverage)
+        vector = [0.0] * self.vector_size
+        payload = {"json": deck.json(), "count": count}
+        point_id = _to_qdrant_id(deck.id)
+        point = PointStruct(id=point_id, vector=vector, payload=payload)
+        self.client.upsert(collection_name=self.collection, points=[point])

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -5,21 +5,22 @@
         {{ 'VALIDATE_FLASHCARDS' | translate }}
     </button>
     <div class="mb-3">
-        <input class="form-control" placeholder="Filter" [(ngModel)]="filterText" (input)="applyFilter()" />
+        <input class="form-control" placeholder="Filter" [(ngModel)]="filterText" />
     </div>
     <div class="mb-3">
         <label class="form-check-label me-2">
-            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByQuestion" (change)="applyFilter()"> Question
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByQuestion"> Question
         </label>
         <label class="form-check-label me-2">
-            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByDeck" (change)="applyFilter()"> Deck
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByDeck"> Deck
         </label>
         <label class="form-check-label me-2">
-            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByTopic" (change)="applyFilter()"> Topic
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByTopic"> Topic
         </label>
         <label class="form-check-label me-2">
-            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByEmbedding" (change)="applyFilter()"> Embedded
+            <input type="checkbox" class="form-check-input me-1" [(ngModel)]="filterByEmbedding"> Embedded
         </label>
+        <button class="btn btn-primary ms-2" type="button" (click)="applyFilter()">Apply Filter</button>
     </div>
 
     <form (ngSubmit)="saveFlashcard()" class="mb-4">

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -37,6 +37,7 @@ export class FlashcardAdminComponent implements OnInit {
   editingCard: Flashcard | null = null;
   availableImages: string[] = [];
   apiUrl = environment.apiBaseUrl;
+  flashcardsLoaded = false;
 
   constructor(
     private flashcardService: FlashcardService,
@@ -45,18 +46,32 @@ export class FlashcardAdminComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.loadFlashcards();
     this.imageService.list().subscribe(list => this.availableImages = list);
   }
 
   loadFlashcards() {
     this.flashcardService.getAll().subscribe(cards => {
       this.flashcards = cards;
-      this.applyFilter();
+      this.flashcardsLoaded = true;
+      this.applyFilterInternal();
     });
   }
 
   applyFilter() {
+    const hasFilter =
+      this.filterText.trim() || this.filterDeck.trim() || this.filterByEmbedding;
+    if (!hasFilter) {
+      this.filtered = [];
+      return;
+    }
+    if (!this.flashcardsLoaded) {
+      this.loadFlashcards();
+    } else {
+      this.applyFilterInternal();
+    }
+  }
+
+  private applyFilterInternal() {
     const text = this.filterText.toLowerCase();
     const deckText = this.filterDeck.toLowerCase();
 

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -18,8 +18,12 @@
     <div class="col-12 col-sm-6 col-lg-4 col-xl-3" *ngFor="let deck of filteredDecks">
       <div class="card mb-4 shadow" (click)="selectDeck(deck)" style="cursor: pointer;">
         <div class="card-body">
-          <h5 class="card-title">{{ deck.name || deck.id }}</h5>
+          <div class="d-flex justify-content-between align-items-start">
+            <h5 class="card-title mb-1">{{ deck.name || deck.id }}</h5>
+            <button class="btn btn-sm btn-outline-secondary" (click)="refreshCoverage(deck, $event)">&#x21bb;</button>
+          </div>
           <p class="card-text">{{ deck.description }}</p>
+          <span class="badge bg-secondary" *ngIf="deck.coverage !== undefined">Coverage: {{ deck.coverage | number:'1.0-0' }}%</span>
         </div>
       </div>
     </div>

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -48,6 +48,14 @@ export class HomeComponent {
     this.router.navigate(['/deck', deck.id]);
   }
 
+  refreshCoverage(deck: Deck, event: Event) {
+    event.stopPropagation();
+    this.deckService.refreshCoverage(deck.id).subscribe({
+      next: (cov) => deck.coverage = cov,
+      error: (err) => this.logger.error('Failed to refresh coverage:', err)
+    });
+  }
+
   submitQuery() {
     if (!this.queryText.trim()) return;
     this.flashcardQueryService.queryString(this.queryText).subscribe({

--- a/frontend/flashcards-ui/src/app/models/deck.ts
+++ b/frontend/flashcards-ui/src/app/models/deck.ts
@@ -2,4 +2,5 @@ export interface Deck {
     id: string;
     name?: string;
     description: string;
+    coverage?: number;
 }

--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Deck } from '../models/deck';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 const API_BASE_URL = environment.apiBaseUrl;
@@ -14,5 +14,11 @@ export class DeckService {
 
   getDecks(): Observable<Deck[]> {
     return this.http.get<Deck[]>(this.apiUrl);
+  }
+
+  refreshCoverage(deckId: string): Observable<number> {
+    return this.http
+      .post<{ coverage: number }>(`${this.apiUrl}/${deckId}/coverage`, {})
+      .pipe(map(res => res.coverage));
   }
 }


### PR DESCRIPTION
## Summary
- compute deck coverage on demand in backend
- expose coverage refresh API
- show coverage and refresh button for decks in home page
- load flashcards in admin view only after applying filter

## Testing
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68654bf67cf4832a9333c8995c0c7d7c