### PR TITLE
Remove coverage calc from deck rebuild

### DIFF
--- a/backend/app/services/qdrant_deck_service.py
+++ b/backend/app/services/qdrant_deck_service.py
@@ -14,7 +14,6 @@ except ImportError:  # pragma: no cover
     PointId = str  # type: ignore
 import json
 from ..models import Deck, Flashcard
-from .llm_service import llm_service
 import uuid
 
 
@@ -63,12 +62,10 @@ class QdrantDeckService:
 
     def rebuild_from_flashcards(self, cards: List[Flashcard]):
         counts: dict[str, int] = {}
-        questions: dict[str, List[str]] = {}
         for c in cards:
             if c.deck_id:
                 counts.setdefault(c.deck_id, 0)
                 counts[c.deck_id] += 1
-                questions.setdefault(c.deck_id, []).append(c.question)
 
         # Remove decks not present anymore
         existing, _ = self.client.scroll(collection_name=self.collection, limit=1000)
@@ -80,8 +77,7 @@ class QdrantDeckService:
             self.client.delete(collection_name=self.collection, points_selector=flt)
 
         for deck_id, count in counts.items():
-            coverage = llm_service.coverage(deck_id, questions.get(deck_id, []))
-            deck = Deck(id=deck_id, description=f"Deck '{deck_id}' ({count} cards)", coverage=coverage)
+            deck = Deck(id=deck_id, description=f"Deck '{deck_id}' ({count} cards)", coverage=0.0)
             vector = [0.0] * self.vector_size
             payload = {"json": deck.json(), "count": count}
             point_id = _to_qdrant_id(deck.id)

--- a/backend/tests/test_qdrant_deck_service.py
+++ b/backend/tests/test_qdrant_deck_service.py
@@ -1,16 +1,10 @@
 import backend.app.services.qdrant_flashcard_service as flashcard_module
-import backend.app.services.qdrant_deck_service as deck_module
 from backend.app.services.qdrant_flashcard_service import QdrantFlashcardService
 from backend.app.services.qdrant_deck_service import QdrantDeckService
 from backend.app.models import Flashcard
 
 
 def test_deck_index_updates(monkeypatch):
-    class DummyLLM:
-        def coverage(self, subject, questions):
-            return 50.0
-
-    monkeypatch.setattr(deck_module, "llm_service", DummyLLM())
 
     deck_svc = QdrantDeckService(collection="deck_test")
     fc_svc = QdrantFlashcardService(collection="deck_cards", deck_service=deck_svc)
@@ -24,18 +18,13 @@ def test_deck_index_updates(monkeypatch):
     card = Flashcard(question="q", answer="a", deck_id="d")
     fc_svc.index_flashcard(card)
     decks = deck_svc.get_all()
-    assert len(decks) == 1 and decks[0].id == "d" and decks[0].coverage == 50.0
+    assert len(decks) == 1 and decks[0].id == "d" and decks[0].coverage == 0.0
 
     fc_svc.delete(card.id)
     assert deck_svc.get_all() == []
 
 
 def test_deck_index_on_update(monkeypatch):
-    class DummyLLM:
-        def coverage(self, subject, questions):
-            return 60.0
-
-    monkeypatch.setattr(deck_module, "llm_service", DummyLLM())
 
     deck_svc = QdrantDeckService(collection="deck_update")
     fc_svc = QdrantFlashcardService(collection="deck_cards2", deck_service=deck_svc)
@@ -53,4 +42,4 @@ def test_deck_index_on_update(monkeypatch):
     ids = [d.id for d in deck_svc.get_all()]
     decks = deck_svc.get_all()
     ids = [d.id for d in decks]
-    assert "e" in ids and "d" not in ids and all(d.coverage == 60.0 for d in decks)
+    assert "e" in ids and "d" not in ids and all(d.coverage == 0.0 for d in decks)


### PR DESCRIPTION
## Summary
- stop calling `llm_service.coverage` in `QdrantDeckService.rebuild_from_flashcards`
- update deck service tests to expect 0 coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655c0237e8832aa78b050c83c54cf4