### PR TITLE
Preserve deck coverage metric in DB

### DIFF
--- a/backend/tests/test_qdrant_deck_service.py
+++ b/backend/tests/test_qdrant_deck_service.py
@@ -43,3 +43,27 @@ def test_deck_index_on_update(monkeypatch):
     decks = deck_svc.get_all()
     ids = [d.id for d in decks]
     assert "e" in ids and "d" not in ids and all(d.coverage == 0.0 for d in decks)
+
+
+def test_coverage_persists(monkeypatch):
+
+    deck_svc = QdrantDeckService(collection="deck_cov")
+    fc_svc = QdrantFlashcardService(collection="deck_cov_cards", deck_service=deck_svc)
+
+    class DummyEmb:
+        def embed(self, text: str):
+            return [0.0] * fc_svc.vector_size
+
+    monkeypatch.setattr(flashcard_module, "embedding_service", DummyEmb())
+
+    card = Flashcard(question="q", answer="a", deck_id="d")
+    fc_svc.index_flashcard(card)
+
+    deck_svc.update_coverage("d", 55.0, 1)
+    assert deck_svc.get_all()[0].coverage == 55.0
+
+    # Adding another card triggers a deck index rebuild which should keep the
+    # existing coverage value.
+    fc_svc.index_flashcard(Flashcard(question="q2", answer="a2", deck_id="d"))
+    decks = deck_svc.get_all()
+    assert len(decks) == 1 and decks[0].coverage == 55.0


### PR DESCRIPTION
## Summary
- keep existing coverage values when rebuilding the deck index
- test that coverage survives rebuilds

## Testing
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686575358f34832aaf45dc8fc84214ac