### PR TITLE
Add deck editing UI and backend support

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -163,6 +163,21 @@ async def refresh_deck_coverage(deck_id: str):
     return {"coverage": coverage}
 
 
+class UpdateDeckRequest(BaseModel):
+    id: str
+    description: str
+
+
+@router.put("/decks/{deck_id}", response_model=Deck)
+async def update_deck(deck_id: str, req: UpdateDeckRequest):
+    updated = main.flashcard_service.rename_deck(deck_id, req.id)
+    main.deck_service.rebuild_from_flashcards(main.flashcard_service.get_all())
+    count = updated
+    deck = Deck(id=req.id, description=req.description, coverage=0.0)
+    main.deck_service.update_deck(deck, count)
+    return deck
+
+
 @router.post("/Flashcards/query-vector", response_model=List[Flashcard])
 async def query_vector(vector: List[float] = Body(...), count: int = 10):
     return main.flashcard_service.query_by_vector(vector, count)

--- a/backend/app/services/qdrant_deck_service.py
+++ b/backend/app/services/qdrant_deck_service.py
@@ -116,3 +116,11 @@ class QdrantDeckService:
         point_id = _to_qdrant_id(deck.id)
         point = PointStruct(id=point_id, vector=vector, payload=payload)
         self.client.upsert(collection_name=self.collection, points=[point])
+
+    def update_deck(self, deck: Deck, count: int):
+        """Update deck details such as description."""
+        vector = [0.0] * self.vector_size
+        payload = {"json": deck.json(), "count": count}
+        point_id = _to_qdrant_id(deck.id)
+        point = PointStruct(id=point_id, vector=vector, payload=payload)
+        self.client.upsert(collection_name=self.collection, points=[point])

--- a/backend/app/services/qdrant_flashcard_service.py
+++ b/backend/app/services/qdrant_flashcard_service.py
@@ -197,6 +197,19 @@ class QdrantFlashcardService:
                 results.append((Flashcard(**p.payload), p.score))
         return results
 
+    def rename_deck(self, old_id: str, new_id: str) -> int:
+        """Rename ``old_id`` deck to ``new_id`` across all flashcards.
+
+        Returns the number of cards updated."""
+        cards = self.get_all()
+        updated = 0
+        for card in cards:
+            if card.deck_id == old_id:
+                card.deck_id = new_id
+                self.update(card)
+                updated += 1
+        return updated
+
     def cleanup_image_fields(self) -> int:
         """Ensure image fields are present and not set to the string ``"none"``.
 

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -20,11 +20,42 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-start">
             <h5 class="card-title mb-1">{{ deck.name || deck.id }}</h5>
-            <button class="btn btn-sm btn-outline-secondary" (click)="refreshCoverage(deck, $event)">&#x21bb;</button>
+            <div>
+              <button class="btn btn-sm btn-outline-secondary" (click)="refreshCoverage(deck, $event)">&#x21bb;</button>
+              <button class="btn btn-sm btn-outline-secondary ms-1" (click)="openEditDeck(deck, $event)">&#9998;</button>
+            </div>
           </div>
           <p class="card-text">{{ deck.description }}</p>
           <span class="badge bg-secondary" *ngIf="deck.coverage !== undefined">Coverage: {{ deck.coverage | number:'1.0-0' }}%</span>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-backdrop show" *ngIf="editingDeck"></div>
+<div class="modal show d-block" tabindex="-1" *ngIf="editingDeck">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit Deck</h5>
+        <button type="button" class="btn-close" (click)="closeEditDeck()"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">Name</label>
+          <input class="form-control" [(ngModel)]="editingDeck.id">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <textarea class="form-control" rows="3" [(ngModel)]="editingDeck.description"></textarea>
+        </div>
+        <p><strong>Flashcards:</strong> {{ editingCount }}</p>
+        <p><strong>Coverage:</strong> {{ editingDeck?.coverage | number:'1.0-0' }}%</p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" (click)="closeEditDeck()">Close</button>
+        <button class="btn btn-primary" (click)="saveDeck()">Save</button>
       </div>
     </div>
   </div>

--- a/frontend/flashcards-ui/src/app/services/deck.service.ts
+++ b/frontend/flashcards-ui/src/app/services/deck.service.ts
@@ -21,4 +21,8 @@ export class DeckService {
       .post<{ coverage: number }>(`${this.apiUrl}/${deckId}/coverage`, {})
       .pipe(map(res => res.coverage));
   }
+
+  updateDeck(oldId: string, deck: Deck): Observable<Deck> {
+    return this.http.put<Deck>(`${this.apiUrl}/${oldId}`, deck);
+  }
 }


### PR DESCRIPTION
## Summary
- implement deck rename/update endpoint in backend
- support updating deck details in qdrant services
- expose update API in frontend service
- add edit button and modal in home component

## Testing
- `pipenv run pytest`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68660ae0f370832a8376333580283b64