### PR TITLE
Fix template errors with flashcard questions

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.ts
@@ -217,7 +217,8 @@ export class FlashcardAdminComponent implements OnInit {
   }
 
   edit(card: Flashcard) {
-    this.newFlashcard = { ...card };
+    // Ensure `questions` is always defined to keep template bindings safe
+    this.newFlashcard = { ...card, questions: card.questions ?? [] };
   }
 
   delete(card: Flashcard) {

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -51,7 +51,8 @@
           <textarea class="form-control" rows="3" [(ngModel)]="editingDeck.description"></textarea>
         </div>
         <p><strong>Flashcards:</strong> {{ editingCount }}</p>
-        <p><strong>Coverage:</strong> {{ editingDeck?.coverage | number:'1.0-0' }}%</p>
+        <!-- editingDeck is guaranteed to be defined inside this block -->
+        <p><strong>Coverage:</strong> {{ editingDeck.coverage | number:'1.0-0' }}%</p>
       </div>
       <div class="modal-footer">
         <button class="btn btn-secondary" (click)="closeEditDeck()">Close</button>

--- a/frontend/flashcards-ui/src/app/models/flashcard.ts
+++ b/frontend/flashcards-ui/src/app/models/flashcard.ts
@@ -1,7 +1,12 @@
 export interface Flashcard {
     id: string;
     question: string;
-    questions?: string[];
+    /**
+     * Alternate phrasings for the question. The backend always
+     * returns this array (possibly empty) so treat it as required
+     * on the frontend as well to simplify template bindings.
+     */
+    questions: string[];
     answer: string;
     score: number;
     deckId: string;


### PR DESCRIPTION
## Summary
- make `questions` array mandatory in the Flashcard model
- remove unnecessary optional chaining in `home.component.html`
- ensure copied flashcards always have a `questions` array

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_686629dfeba8832abaece6d3e1529c89