### PR TITLE
Fix manage flashcards form

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-admin/flashcard-admin.component.html
@@ -27,10 +27,10 @@
         <input class="form-control mb-2" placeholder="Question" [(ngModel)]="newFlashcard.question" name="question"
             required />
         <div *ngFor="let q of newFlashcard.questions; let i = index">
-            <input class="form-control mb-2" [(ngModel)]="newFlashcard.questions[i]" placeholder="Question {{i + 1}}" />
+            <input class="form-control mb-2" [(ngModel)]="newFlashcard.questions[i]" placeholder="Question {{i + 1}}" [ngModelOptions]="{standalone: true}" />
         </div>
         <div class="input-group mb-2">
-            <input class="form-control" placeholder="Add question" [(ngModel)]="newQuestion" />
+            <input class="form-control" placeholder="Add question" [(ngModel)]="newQuestion" [ngModelOptions]="{standalone: true}" />
             <button class="btn btn-outline-secondary" type="button" (click)="addQuestion()">Add</button>
         </div>
         <label for="questionImageSelect" class="form-label">Question Image</label>


### PR DESCRIPTION
## Summary
- allow ngModel binding on repeated question inputs
- ensure the "Add question" field works inside the form

## Testing
- `pipenv run pytest`
- `npm test --silent` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68667a5ab7ac832a97ba931da88565df