### PR TITLE
Improve code detection for flashcard answers

### DIFF
--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -32,6 +32,8 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0",
+    "highlight.js": "^11.9.0",
+    "ngx-highlightjs": "^6.0.3",
     "@ionic/angular": "^8.0.0",
     "@capacitor/core": "^5.0.0"
   },

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -14,5 +14,6 @@
   *ngIf="isCode"
   (click)="onClick()"
   [ngStyle]="{ 'text-align': alignment }"
-  [innerHTML]="formatted"
-></pre>
+>
+  <code [highlight]="formatted"></code>
+</pre>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HighlightModule } from 'ngx-highlightjs';
 import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-answer',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HighlightModule],
   templateUrl: './flashcard-answer.component.html',
   styleUrls: ['./flashcard-answer.component.css']
 })
@@ -26,13 +27,39 @@ export class FlashcardAnswerComponent implements OnChanges {
   }
 
   private detectCode(text: string): boolean {
-    return text.includes('```');
+    if (text.includes('```')) {
+      return true;
+    }
+
+    const keywords = [
+      'const ',
+      'let ',
+      'var ',
+      'function ',
+      'class ',
+      'def ',
+      'return ',
+      'import ',
+      'from ',
+      '#include ',
+    ];
+    if (keywords.some((kw) => text.includes(kw))) {
+      return true;
+    }
+
+    if (/[{};]/.test(text)) {
+      return true;
+    }
+
+    const indentedLines = text
+      .split('\n')
+      .filter((line) => line.startsWith('    ') || line.startsWith('\t'));
+    return indentedLines.length >= 2;
   }
 
   private formatAnswer(text: string): string {
     if (this.isCode) {
-      let code = text.replace(/```/g, '').trim();
-      return this.highlightCode(code);
+      return text.replace(/```/g, '').trim();
     }
 
     let processed = text.replace(/(\d+\.)/g, '\n$1');
@@ -68,15 +95,6 @@ export class FlashcardAnswerComponent implements OnChanges {
       .join('\n');
   }
 
-  private highlightCode(code: string): string {
-    const escaped = code
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    const keywords = ['const', 'let', 'function', 'return', 'if', 'else', 'for', 'while'];
-    const kwRegex = new RegExp('\\b(' + keywords.join('|') + ')\\b', 'g');
-    return escaped.replace(kwRegex, '<span class="keyword">$1</span>');
-  }
 
   onClick() {
     this.clicked.emit();

--- a/frontend/flashcards-ui/src/styles.css
+++ b/frontend/flashcards-ui/src/styles.css
@@ -1,1 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
+@import '~highlight.js/styles/github.css';


### PR DESCRIPTION
## Summary
- expand code detection heuristics beyond ``` markers
- use ngx-highlightjs to render code snippets

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868bc2d55c8832abf893b0f069b0b7a