### PR TITLE
Remove highlight.js dependency for offline build

### DIFF
--- a/frontend/flashcards-ui/package.json
+++ b/frontend/flashcards-ui/package.json
@@ -32,8 +32,6 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0",
-    "highlight.js": "^11.9.0",
-    "ngx-highlightjs": "^6.0.3",
     "@ionic/angular": "^8.0.0",
     "@capacitor/core": "^5.0.0"
   },

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
@@ -6,10 +6,7 @@
   background-color: #fffbe6;
   font-family: 'Courier New', monospace;
   overflow-wrap: anywhere;
-}
-.code-answer .keyword {
-  color: #d73a49;
-  font-weight: bold;
+  white-space: pre-wrap;
 }
 
 .flashcard-image {

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -15,5 +15,5 @@
   (click)="onClick()"
   [ngStyle]="{ 'text-align': alignment }"
 >
-  <code [highlight]="formatted"></code>
+  <code>{{ formatted }}</code>
 </pre>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,12 +1,11 @@
 import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HighlightModule } from 'ngx-highlightjs';
 import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-flashcard-answer',
   standalone: true,
-  imports: [CommonModule, HighlightModule],
+  imports: [CommonModule],
   templateUrl: './flashcard-answer.component.html',
   styleUrls: ['./flashcard-answer.component.css']
 })

--- a/frontend/flashcards-ui/src/styles.css
+++ b/frontend/flashcards-ui/src/styles.css
@@ -1,2 +1,9 @@
-/* You can add global styles to this file, and also import other style files */
-@import '~highlight.js/styles/github.css';
+/* Global styles */
+pre code {
+  display: block;
+  padding: 0.5rem;
+  background-color: #f6f8fa;
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- remove `highlight.js` and `ngx-highlightjs`
- show code blocks without highlight.js dependency
- adjust global CSS for simple code styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868beaa5da0832abde54ad966c6d861