### PR TITLE
Add mobile scroll view for flashcards

### DIFF
--- a/frontend/flashcards-ui/src/app/app.routes.ts
+++ b/frontend/flashcards-ui/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { FlashcardComponent } from './flashcard/flashcard.component';
+import { FlashcardScrollComponent } from './flashcard/flashcard-scroll.component';
 import { HelpPageComponent } from './help-page/help-page.component';
 import { AboutComponent } from './about/about.component';
 import { LearningPathComponent } from './learning-path/learning-path.component';
@@ -15,6 +16,7 @@ import { ImageManagerComponent } from './image-manager/image-manager.component';
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'deck/:deckId', component: FlashcardComponent },
+  { path: 'scroll/:deckId', component: FlashcardScrollComponent },
   { path: 'manage-flashcards', component: FlashcardAdminComponent },
   { path: 'manage-images', component: ImageManagerComponent },
   { path: 'learning-paths', component: LearningPathComponent },

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
@@ -1,0 +1,37 @@
+.scroll-wrapper {
+  scroll-snap-type: y mandatory;
+  overflow-y: auto;
+  height: 100vh;
+}
+
+.qa-section {
+  height: 100vh;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.question {
+  background-color: #f5fff5;
+}
+
+.answer {
+  background-color: #eaf7ff;
+}
+
+.card-text {
+  font-family: 'Courier New', monospace;
+  font-size: 1.1rem;
+  white-space: pre-wrap;
+  width: 100%;
+}
+
+.flashcard-image {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 1rem;
+}

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
@@ -1,0 +1,16 @@
+<div class="scroll-wrapper" *ngIf="flashcards.length">
+  <ng-container *ngFor="let card of flashcards">
+    <section class="qa-section question">
+      <img
+        *ngIf="card.questionImage"
+        [src]="apiUrl + '/images/' + card.questionImage"
+        class="flashcard-image"
+        alt="question image"
+      />
+      <pre class="card-text">{{ card.question }}</pre>
+    </section>
+    <section class="qa-section answer">
+      <app-flashcard-answer [answer]="card.answer" [image]="card.answerImage || ''"></app-flashcard-answer>
+    </section>
+  </ng-container>
+</div>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { Flashcard } from '../models/flashcard';
+import { FlashcardService } from '../services/flashcard.service';
+import { FlashcardAnswerComponent } from './flashcard-answer.component';
+import { TranslatePipe } from '../services/translate.pipe';
+import { environment } from '../../environments/environment';
+import { LoggerService } from '../services/logger.service';
+import { LocalScoreService } from '../services/local-score.service';
+
+@Component({
+  selector: 'app-flashcard-scroll',
+  standalone: true,
+  imports: [CommonModule, FlashcardAnswerComponent, TranslatePipe],
+  templateUrl: './flashcard-scroll.component.html',
+  styleUrls: ['./flashcard-scroll.component.css']
+})
+export class FlashcardScrollComponent implements OnInit {
+  flashcards: Flashcard[] = [];
+  apiUrl = environment.apiBaseUrl;
+
+  constructor(
+    private route: ActivatedRoute,
+    private flashcardService: FlashcardService,
+    private logger: LoggerService,
+    private localScore: LocalScoreService
+  ) {}
+
+  ngOnInit(): void {
+    const deckId = this.route.snapshot.paramMap.get('deckId');
+    if (!deckId) {
+      this.logger.warn('Missing deckId!');
+      return;
+    }
+
+    if (deckId.startsWith('temp-')) {
+      const raw = sessionStorage.getItem(deckId);
+      if (raw) {
+        try {
+          const temp = JSON.parse(raw);
+          this.flashcards = (temp.flashcards || []).map((card: any) => ({
+            ...(card || {}),
+            id: typeof card.id === 'string' ? card.id : card.id?.uuid || '',
+            userScore: this.localScore.getScore(
+              typeof card.id === 'string' ? card.id : card.id?.uuid || ''
+            )
+          }));
+        } catch (e) {
+          this.logger.error('Failed to parse temp deck', e);
+        }
+      }
+    } else {
+      this.flashcardService.getRandom(deckId, 50).subscribe(cards => {
+        this.flashcards = cards.map(card => ({
+          ...card,
+          id: typeof card.id === 'string' ? card.id : (card as any).id?.uuid || '',
+          userScore: this.localScore.getScore(
+            typeof card.id === 'string' ? card.id : (card as any).id?.uuid || ''
+          )
+        }));
+      });
+    }
+  }
+}

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -48,7 +48,12 @@ export class HomeComponent {
 
   selectDeck(deck: Deck) {
     this.logger.info('select deck' + deck.id);
-    this.router.navigate(['/deck', deck.id]);
+    const mobile = window.innerWidth <= 768;
+    if (mobile) {
+      this.router.navigate(['/scroll', deck.id]);
+    } else {
+      this.router.navigate(['/deck', deck.id]);
+    }
   }
 
   refreshCoverage(deck: Deck, event: Event) {


### PR DESCRIPTION
## Summary
- create `FlashcardScrollComponent` to display flashcards in a vertical feed
- register `/scroll/:deckId` route
- navigate to the scroll view from deck selection on mobile

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868c4a1f8b8832ab5cd929b3cf52130