### PR TITLE
Add view choice for mobile decks

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
@@ -23,6 +23,10 @@
   background-color: #eaf7ff;
 }
 
+.question-text {
+  background-color: #f5fff5;
+}
+
 .card-text {
   font-family: 'Courier New', monospace;
   font-size: 1.1rem;
@@ -34,4 +38,10 @@
   max-width: 100%;
   height: auto;
   margin-bottom: 1rem;
+}
+
+.alert-info {
+  white-space: pre-wrap;
+  font-family: 'Courier New', monospace;
+  font-size: 0.95rem;
 }

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
@@ -7,10 +7,30 @@
         class="flashcard-image"
         alt="question image"
       />
-      <pre class="card-text">{{ card.question }}</pre>
+      <pre class="card-text question-text" (click)="flip(card)">{{ card.question }}</pre>
+      <div class="d-flex justify-content-center mt-3">
+        <button class="btn btn-secondary me-2" (click)="flip(card)">🔁 Flip</button>
+        <button class="btn btn-success me-2" (click)="vote(card, true)">👍</button>
+        <button class="btn btn-danger me-2" (click)="vote(card, false)">👎</button>
+        <button class="btn btn-info me-2" (click)="card.showExplanation = !card.showExplanation">ℹ️ {{ 'HELP_EXPLAIN' | translate }}</button>
+        <button class="btn btn-warning me-2" (click)="readAloud(card)">🔊 Voice</button>
+      </div>
     </section>
-    <section class="qa-section answer">
-      <app-flashcard-answer [answer]="card.answer" [image]="card.answerImage || ''"></app-flashcard-answer>
+    <section class="qa-section answer" *ngIf="card.showAnswer">
+      <app-flashcard-answer
+        [answer]="card.answer"
+        [image]="card.answerImage || ''"
+        (clicked)="flip(card)"
+      ></app-flashcard-answer>
+      <div *ngIf="card.showExplanation" class="alert alert-info text-start mt-3">
+        <img
+          *ngIf="card.explanationImage"
+          [src]="apiUrl + '/images/' + card.explanationImage"
+          class="flashcard-image"
+          alt="explanation image"
+        />
+        {{ card.explanation }}
+      </div>
     </section>
   </ng-container>
 </div>

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -61,3 +61,22 @@
     </div>
   </div>
 </div>
+
+<div class="modal-backdrop show" *ngIf="viewSelectDeck"></div>
+<div class="modal show d-block" tabindex="-1" *ngIf="viewSelectDeck">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ viewSelectDeck?.name || viewSelectDeck?.id }}</h5>
+        <button type="button" class="btn-close" (click)="closeViewSelection()"></button>
+      </div>
+      <div class="modal-body">
+        <p>{{ 'CHOOSE_VIEW' | translate }}</p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" (click)="openDeckView()">{{ 'DECK_VIEW' | translate }}</button>
+        <button class="btn btn-primary" (click)="openScrollView()">{{ 'SCROLL_VIEW' | translate }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/flashcards-ui/src/app/home/home.component.ts
+++ b/frontend/flashcards-ui/src/app/home/home.component.ts
@@ -23,6 +23,7 @@ export class HomeComponent {
   editingDeck: Deck | null = null;
   originalDeckId: string = '';
   editingCount = 0;
+  viewSelectDeck: Deck | null = null;
   get filteredDecks(): Deck[] {
     const text = this.filterText.toLowerCase();
     return this.decks.filter(deck =>
@@ -50,7 +51,7 @@ export class HomeComponent {
     this.logger.info('select deck' + deck.id);
     const mobile = window.innerWidth <= 768;
     if (mobile) {
-      this.router.navigate(['/scroll', deck.id]);
+      this.viewSelectDeck = deck;
     } else {
       this.router.navigate(['/deck', deck.id]);
     }
@@ -75,6 +76,24 @@ export class HomeComponent {
     this.editingDeck = null;
     this.originalDeckId = '';
     this.editingCount = 0;
+  }
+
+  closeViewSelection() {
+    this.viewSelectDeck = null;
+  }
+
+  openDeckView() {
+    if (this.viewSelectDeck) {
+      this.router.navigate(['/deck', this.viewSelectDeck.id]);
+      this.closeViewSelection();
+    }
+  }
+
+  openScrollView() {
+    if (this.viewSelectDeck) {
+      this.router.navigate(['/scroll', this.viewSelectDeck.id]);
+      this.closeViewSelection();
+    }
   }
 
   saveDeck() {

--- a/frontend/flashcards-ui/src/assets/i18n/en.json
+++ b/frontend/flashcards-ui/src/assets/i18n/en.json
@@ -46,5 +46,8 @@
   "FILTER_FLASHCARDS": "Filter flashcards...",
   "ADD_PATH": "Add Path",
   "PASSED_ALL": "All flashcards passed with score > 2!",
-  "VALIDATE_FLASHCARDS": "Validate Flashcards"
+  "VALIDATE_FLASHCARDS": "Validate Flashcards",
+  "CHOOSE_VIEW": "Choose view",
+  "DECK_VIEW": "Deck View",
+  "SCROLL_VIEW": "Scroll View"
 }

--- a/frontend/flashcards-ui/src/assets/i18n/he.json
+++ b/frontend/flashcards-ui/src/assets/i18n/he.json
@@ -46,5 +46,8 @@
   "FILTER_FLASHCARDS": "סנן כרטיסיות...",
   "ADD_PATH": "הוסף מסלול",
   "PASSED_ALL": "כל הכרטיסיות עברו עם ציון גדול מ-2!",
-  "VALIDATE_FLASHCARDS": "בדיקת כרטיסיות"
+  "VALIDATE_FLASHCARDS": "בדיקת כרטיסיות",
+  "CHOOSE_VIEW": "בחר תצוגה",
+  "DECK_VIEW": "תצוגת חפיסה",
+  "SCROLL_VIEW": "תצוגת גלילה"
 }


### PR DESCRIPTION
## Summary
- allow mobile users to choose deck or scroll view
- add interactive buttons to questions in scroll view

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868c6d426a8832aa4b9cdc6a46de3f9