### PR TITLE
Fix Angular compilation errors

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
@@ -9,6 +9,12 @@ import { environment } from '../../environments/environment';
 import { LoggerService } from '../services/logger.service';
 import { LocalScoreService } from '../services/local-score.service';
 
+export interface ScrollCard extends Flashcard {
+  showAnswer?: boolean;
+  showExplanation?: boolean;
+  userScore?: number;
+}
+
 @Component({
   selector: 'app-flashcard-scroll',
   standalone: true,
@@ -16,12 +22,6 @@ import { LocalScoreService } from '../services/local-score.service';
   templateUrl: './flashcard-scroll.component.html',
   styleUrls: ['./flashcard-scroll.component.css']
 })
-export interface ScrollCard extends Flashcard {
-  showAnswer?: boolean;
-  showExplanation?: boolean;
-  userScore?: number;
-}
-
 export class FlashcardScrollComponent implements OnInit {
   flashcards: ScrollCard[] = [];
   apiUrl = environment.apiBaseUrl;


### PR DESCRIPTION
## Summary
- move ScrollCard interface above the component decorator
- ensure decorator applies to FlashcardScrollComponent

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868cab6e930832ab3bd9212d0fb6b2f