### PR TITLE
Fix scroll view to show answers

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
@@ -1,3 +1,4 @@
+<app-menu></app-menu>
 <div class="scroll-wrapper" *ngIf="flashcards.length">
   <ng-container *ngFor="let card of flashcards">
     <section class="qa-section question">
@@ -7,22 +8,19 @@
         class="flashcard-image"
         alt="question image"
       />
-      <pre class="card-text question-text" (click)="flip(card)">{{ card.question }}</pre>
+      <pre class="card-text question-text">{{ card.question }}</pre>
       <div class="d-flex justify-content-center mt-3">
-        <button class="btn btn-secondary me-2" (click)="flip(card)">🔁 Flip</button>
         <button class="btn btn-success me-2" (click)="vote(card, true)">👍</button>
         <button class="btn btn-danger me-2" (click)="vote(card, false)">👎</button>
-        <button class="btn btn-info me-2" (click)="card.showExplanation = !card.showExplanation">ℹ️ {{ 'HELP_EXPLAIN' | translate }}</button>
         <button class="btn btn-warning me-2" (click)="readAloud(card)">🔊 Voice</button>
       </div>
     </section>
-    <section class="qa-section answer" *ngIf="card.showAnswer">
+    <section class="qa-section answer">
       <app-flashcard-answer
         [answer]="card.answer"
         [image]="card.answerImage || ''"
-        (clicked)="flip(card)"
       ></app-flashcard-answer>
-      <div *ngIf="card.showExplanation" class="alert alert-info text-start mt-3">
+      <div *ngIf="card.explanation" class="alert alert-info text-start mt-3">
         <img
           *ngIf="card.explanationImage"
           [src]="apiUrl + '/images/' + card.explanationImage"

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
@@ -5,20 +5,19 @@ import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';
 import { FlashcardAnswerComponent } from './flashcard-answer.component';
 import { TranslatePipe } from '../services/translate.pipe';
+import { MenuComponent } from '../menu/menu.component';
 import { environment } from '../../environments/environment';
 import { LoggerService } from '../services/logger.service';
 import { LocalScoreService } from '../services/local-score.service';
 
 export interface ScrollCard extends Flashcard {
-  showAnswer?: boolean;
-  showExplanation?: boolean;
   userScore?: number;
 }
 
 @Component({
   selector: 'app-flashcard-scroll',
   standalone: true,
-  imports: [CommonModule, FlashcardAnswerComponent, TranslatePipe],
+  imports: [CommonModule, FlashcardAnswerComponent, TranslatePipe, MenuComponent],
   templateUrl: './flashcard-scroll.component.html',
   styleUrls: ['./flashcard-scroll.component.css']
 })
@@ -63,16 +62,8 @@ export class FlashcardScrollComponent implements OnInit {
       ...(raw || {}),
       id,
       userScore: this.localScore.getScore(id),
-      showAnswer: false,
-      showExplanation: false,
+      showAnswer: true,
     } as ScrollCard;
-  }
-
-  flip(card: ScrollCard) {
-    card.showAnswer = !card.showAnswer;
-    if (!card.showAnswer) {
-      card.showExplanation = false;
-    }
   }
 
   userScoreOf(card: ScrollCard): number {
@@ -94,8 +85,11 @@ export class FlashcardScrollComponent implements OnInit {
   }
 
   readAloud(card: ScrollCard) {
-    let text = card.showAnswer ? card.answer : card.question;
-    if (card.showExplanation && card.explanation) {
+    let text = card.question;
+    if (card.answer) {
+      text += '. ' + card.answer;
+    }
+    if (card.explanation) {
       text += '. ' + card.explanation;
     }
     if (text) {


### PR DESCRIPTION
## Summary
- enable answers by default in scroll view
- remove flip & explanation buttons
- adjust `readAloud` to speak full card
- add `app-menu` into scroll view

## Testing
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6868cc82e524832a8414c59bbd3c2ebf