### PR TITLE
Fix template warnings

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from '@angular/router';
 import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';
 import { FlashcardAnswerComponent } from './flashcard-answer.component';
-import { TranslatePipe } from '../services/translate.pipe';
 import { MenuComponent } from '../menu/menu.component';
 import { environment } from '../../environments/environment';
 import { LoggerService } from '../services/logger.service';
@@ -17,7 +16,7 @@ export interface ScrollCard extends Flashcard {
 @Component({
   selector: 'app-flashcard-scroll',
   standalone: true,
-  imports: [CommonModule, FlashcardAnswerComponent, TranslatePipe, MenuComponent],
+  imports: [CommonModule, FlashcardAnswerComponent, MenuComponent],
   templateUrl: './flashcard-scroll.component.html',
   styleUrls: ['./flashcard-scroll.component.css']
 })

--- a/frontend/flashcards-ui/src/app/home/home.component.html
+++ b/frontend/flashcards-ui/src/app/home/home.component.html
@@ -67,7 +67,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{{ viewSelectDeck?.name || viewSelectDeck?.id }}</h5>
+        <h5 class="modal-title">{{ viewSelectDeck.name || viewSelectDeck.id }}</h5>
         <button type="button" class="btn-close" (click)="closeViewSelection()"></button>
       </div>
       <div class="modal-body">


### PR DESCRIPTION
## Summary
- remove unused TranslatePipe from FlashcardScrollComponent
- simplify viewSelectDeck name rendering

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868cff2648c832aa5cd4625c97f5eae