### PR TITLE
Fix duplicate menu on scroll page

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
@@ -1,4 +1,3 @@
-<app-menu></app-menu>
 <div class="scroll-wrapper" *ngIf="flashcards.length">
   <ng-container *ngFor="let card of flashcards">
     <section class="qa-section question">

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from '@angular/router';
 import { Flashcard } from '../models/flashcard';
 import { FlashcardService } from '../services/flashcard.service';
 import { FlashcardAnswerComponent } from './flashcard-answer.component';
-import { MenuComponent } from '../menu/menu.component';
 import { environment } from '../../environments/environment';
 import { LoggerService } from '../services/logger.service';
 import { LocalScoreService } from '../services/local-score.service';
@@ -16,7 +15,7 @@ export interface ScrollCard extends Flashcard {
 @Component({
   selector: 'app-flashcard-scroll',
   standalone: true,
-  imports: [CommonModule, FlashcardAnswerComponent, MenuComponent],
+  imports: [CommonModule, FlashcardAnswerComponent],
   templateUrl: './flashcard-scroll.component.html',
   styleUrls: ['./flashcard-scroll.component.css']
 })


### PR DESCRIPTION
## Summary
- remove `MenuComponent` from flashcard scroll view
- update template so the scroll page doesn't render the menu twice

## Testing
- `pytest -q`
- `npm test --silent` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6868e2c88afc832aad9ab6aa42e76d1d