### PR TITLE
Improve answer box wrapping

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.css
@@ -21,7 +21,8 @@ pre.card-text {
   color: #2d2d2d;
   white-space: pre-wrap;
   text-align: left;
-  overflow-x: auto;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
   line-height: 1.5;
   margin-bottom: 1rem;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);

--- a/frontend/flashcards-ui/src/styles.css
+++ b/frontend/flashcards-ui/src/styles.css
@@ -4,6 +4,7 @@ pre code {
   padding: 0.5rem;
   background-color: #f6f8fa;
   border-radius: 4px;
-  overflow-x: auto;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary
- update card-text styles to avoid horizontal scroll
- wrap code snippets without scroll

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f3c992a8832a9071e3454abbc11c