### PR TITLE
Remove auto flip on click

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
@@ -1,6 +1,8 @@
 .answer-text {
   background-color: #eaf7ff;
   overflow-wrap: anywhere;
+  overflow-x: hidden;
+  width: 100%;
 }
 .code-answer {
   background-color: #fffbe6;
@@ -8,6 +10,8 @@
   font-size: 0.85em;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+  overflow-x: hidden;
+  width: 100%;
 }
 
 .flashcard-image {

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -5,14 +5,13 @@
     class="flashcard-image"
     alt="answer image"
   />
-  <pre class="card-text answer-text" (click)="onClick()" [ngStyle]="{ 'text-align': alignment }">
+  <pre class="card-text answer-text" [ngStyle]="{ 'text-align': alignment }">
     {{ formatted }}
   </pre>
 </div>
 <pre
   class="card-text code-answer"
   *ngIf="isCode"
-  (click)="onClick()"
   [ngStyle]="{ 'text-align': alignment }"
 >
   <code>{{ formatted }}</code>

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { environment } from '../../environments/environment';
 
@@ -12,7 +12,6 @@ import { environment } from '../../environments/environment';
 export class FlashcardAnswerComponent implements OnChanges {
   @Input() answer = '';
   @Input() image = '';
-  @Output() clicked = new EventEmitter<void>();
 
   isCode = false;
   formatted = '';
@@ -94,10 +93,6 @@ export class FlashcardAnswerComponent implements OnChanges {
       .join('\n');
   }
 
-
-  onClick() {
-    this.clicked.emit();
-  }
 
   private detectAlignment(text: string): 'left' | 'right' {
     const hebrew = (text.match(/[\u0590-\u05FF]/g) || []).length;

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard.component.html
@@ -8,12 +8,11 @@
         class="flashcard-image"
         alt="question image"
       />
-      <pre class="card-text display-6 question-text text-start" *ngIf="!showAnswer" (click)="flip()">{{ flashcards[currentIndex].question }}</pre>
+      <pre class="card-text display-6 question-text text-start" *ngIf="!showAnswer">{{ flashcards[currentIndex].question }}</pre>
       <app-flashcard-answer
         *ngIf="showAnswer"
         [answer]="flashcards[currentIndex].answer"
         [image]="flashcards[currentIndex].answerImage || ''"
-        (clicked)="flip()"
       ></app-flashcard-answer>
       <div *ngIf="showExplanation" class="alert alert-info text-start mt-3">
         <img


### PR DESCRIPTION
## Summary
- disable question/answer click events that flip cards
- adjust answer layout to prevent horizontal scrolling

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6868f913860c832ab20dfa7ff4af2cdb