### PR TITLE
Improve answer formatting and overflow handling

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.ts
@@ -66,8 +66,22 @@ export class FlashcardAnswerComponent implements OnChanges {
       processed = processed.slice(1);
     }
     processed = processed.replace(/\n{2,}/g, '\n');
-    processed = this.wrapLongLines(processed.trim());
+    processed = this.applyIndentation(processed.trim());
+    processed = this.wrapLongLines(processed);
     return processed;
+  }
+
+  private applyIndentation(text: string): string {
+    return text
+      .split('\n')
+      .map((line) => {
+        const trimmed = line.trimStart();
+        if (/^(\d+\.|-)/.test(trimmed)) {
+          return '  ' + trimmed;
+        }
+        return line;
+      })
+      .join('\n');
   }
 
   private wrapLongLines(text: string, maxChars = 70): string {

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
@@ -5,7 +5,7 @@
 }
 
 .qa-section {
-  height: 100vh;
+  min-height: 100vh;
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
@@ -31,6 +31,8 @@
   font-family: 'Courier New', monospace;
   font-size: 1.1rem;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- preserve long answers by allowing sections to grow beyond the viewport
- wrap long words and hide horizontal overflow in scroll view
- indent list-like lines in flashcard answers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686904006e78832a935788e140cd2b24