### PR TITLE
Fix wrap in flashcard answers

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.css
@@ -2,6 +2,7 @@
   background-color: #eaf7ff;
   overflow-wrap: anywhere;
   overflow-x: hidden;
+  white-space: pre-wrap;
   width: 100%;
 }
 .code-answer {

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-answer.component.html
@@ -5,14 +5,6 @@
     class="flashcard-image"
     alt="answer image"
   />
-  <pre class="card-text answer-text" [ngStyle]="{ 'text-align': alignment }">
-    {{ formatted }}
-  </pre>
+  <pre class="card-text answer-text" [ngStyle]="{ 'text-align': alignment }">{{ formatted }}</pre>
 </div>
-<pre
-  class="card-text code-answer"
-  *ngIf="isCode"
-  [ngStyle]="{ 'text-align': alignment }"
->
-  <code>{{ formatted }}</code>
-</pre>
+<pre class="card-text code-answer" *ngIf="isCode" [ngStyle]="{ 'text-align': alignment }"><code>{{ formatted }}</code></pre>


### PR DESCRIPTION
## Summary
- ensure flashcard answers wrap naturally
- remove leading whitespace in flashcard answer template

## Testing
- `npm test --prefix frontend/flashcards-ui` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68690c9b4364832a91fe98d9b71952ca