### PR TITLE
Fix UI for nginx subpath

### DIFF
--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -4,3 +4,4 @@ JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
 LLM_PROVIDER=openai
 LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."
 OPENAI_API_KEY=sk-your-openai-api-key
+BASE_PATH=/flashcards/api

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -4,3 +4,4 @@ JWT_KEY=A_SUPER_SECRET_KEY_12345678901234567890!@#abcdEFGHijklMNOPqrstuvWXyz
 LLM_PROVIDER=openai
 LLM_SYSTEM_PROMPT="You are a helpful assistant that answers questions for a flashcard. Respond in JSON with 'answer' and 'explanation' fields."
 OPENAI_API_KEY=sk-your-openai-api-key
+BASE_PATH=/flashcards/api

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,8 @@ os.makedirs(log_dir, exist_ok=True)
 log_file = os.path.join(log_dir, 'backend.log')
 logging.basicConfig(level=logging.DEBUG, filename=log_file, filemode='a')
 
-app = FastAPI(title="Flashcards API (Python)")
+BASE_PATH = os.getenv("BASE_PATH", "")
+app = FastAPI(title="Flashcards API (Python)", root_path=BASE_PATH)
 
 app.add_middleware(
     CORSMiddleware,

--- a/frontend/flashcards-ui/angular.json
+++ b/frontend/flashcards-ui/angular.json
@@ -16,6 +16,7 @@
             "outputPath": "dist/flashcards-ui",
             "index": "src/index.html",
             "browser": "src/main.ts",
+            "baseHref": "/flashcards/",
             "polyfills": [
               "zone.js"
             ],

--- a/frontend/flashcards-ui/nginx.conf
+++ b/frontend/flashcards-ui/nginx.conf
@@ -10,6 +10,11 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     location / {
-        try_files $uri $uri/ /index.html;
+        return 301 /flashcards/;
+    }
+
+    location /flashcards/ {
+        alias /usr/share/nginx/html/;
+        try_files $uri $uri/ /flashcards/index.html;
     }
 }

--- a/frontend/flashcards-ui/nginx.conf
+++ b/frontend/flashcards-ui/nginx.conf
@@ -17,4 +17,10 @@ server {
         alias /usr/share/nginx/html/;
         try_files $uri $uri/ /flashcards/index.html;
     }
+
+    location /flashcards/api/ {
+        proxy_pass http://backend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
 }

--- a/frontend/flashcards-ui/proxy.conf.json
+++ b/frontend/flashcards-ui/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/flashcardbulkimport": {
-    "target": "http://10.0.0.9:5000",
+    "target": "http://10.0.0.9:5000/flashcards/api",
     "secure": false
   }
 }

--- a/frontend/flashcards-ui/src/app/app.config.ts
+++ b/frontend/flashcards-ui/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 // import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withFetch, HTTP_INTERCEPTORS, withInterceptorsFromDi } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withHashLocation } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { routes } from './app.routes';
 import { AuthInterceptor } from './services/auth.interceptor';
@@ -13,7 +13,7 @@ export const appConfig: ApplicationConfig = {
     // Hydration is only needed for SSR. Remove or comment out to avoid NG0505 warning in CSR-only builds.
     // provideClientHydration(withEventReplay()),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
-    provideRouter(routes),
+    provideRouter(routes, withHashLocation()),
     provideServiceWorker('ngsw-worker.js'),
     // AuthInterceptor is provided here to ensure it is available for all HTTP requests
     // This is necessary for the AuthService to add the Authorization header to requests.

--- a/frontend/flashcards-ui/src/app/services/flashcard-query.service.ts
+++ b/frontend/flashcards-ui/src/app/services/flashcard-query.service.ts
@@ -2,10 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-const API_BASE_URL =
-  window.location.hostname === 'localhost'
-    ? 'http://localhost:5000'
-    : `http://${window.location.hostname}:5000`;
+import { environment } from '../../environments/environment';
+
+const API_BASE_URL = environment.apiBaseUrl;
 
 @Injectable({ providedIn: 'root' })
 export class FlashcardQueryService {

--- a/frontend/flashcards-ui/src/app/services/learning-path.service.ts
+++ b/frontend/flashcards-ui/src/app/services/learning-path.service.ts
@@ -3,10 +3,9 @@ import { Injectable } from '@angular/core';
 import { LearningPath } from '../models/LearningPath';
 import { Observable } from 'rxjs';
 
-const API_BASE_URL =
-  window.location.hostname === 'localhost'
-    ? 'http://localhost:5000'
-    : `http://${window.location.hostname}:5000`;
+import { environment } from '../../environments/environment';
+
+const API_BASE_URL = environment.apiBaseUrl;
 
 @Injectable({ providedIn: 'root' })
 export class LearningPathService {

--- a/frontend/flashcards-ui/src/environments/environment.prod.ts
+++ b/frontend/flashcards-ui/src/environments/environment.prod.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: true,
   // In production the API runs on the host machine. Update the base URL
   // so mobile clients can reach it using the server's IP address.
-  apiBaseUrl: 'http://10.0.0.9:5000',
+  apiBaseUrl: '/flashcards/api',
   logLevel: 'info'
 };

--- a/frontend/flashcards-ui/src/environments/environment.ts
+++ b/frontend/flashcards-ui/src/environments/environment.ts
@@ -6,6 +6,6 @@ export const environment = {
   // Use the current hostname so mobile devices on the same network can reach
   // the backend when running the app with `ng serve --host 0.0.0.0`.
   // Falls back to localhost for server-side rendering.
-  apiBaseUrl: `${protocol}//${host}:5000`,
+  apiBaseUrl: `${protocol}//${host}:5000/flashcards/api`,
   logLevel: 'debug'
 };

--- a/frontend/flashcards-ui/src/index.html
+++ b/frontend/flashcards-ui/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>FlashcardsUi</title>
-  <base href="/">
+  <base href="/flashcards/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1976d2">
   <link rel="manifest" href="manifest.webmanifest">

--- a/frontend/flashcards-ui/src/ngsw-config.json
+++ b/frontend/flashcards-ui/src/ngsw-config.json
@@ -29,10 +29,10 @@
     {
       "name": "decks-api",
       "urls": [
-        "/decks",
-        "/decks/**",
-        "http://10.0.0.9:5000/decks",
-        "http://10.0.0.9:5000/decks/**"
+        "/flashcards/api/decks",
+        "/flashcards/api/decks/**",
+        "http://10.0.0.9:5000/flashcards/api/decks",
+        "http://10.0.0.9:5000/flashcards/api/decks/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",
@@ -44,10 +44,10 @@
     {
       "name": "flashcards-api",
       "urls": [
-        "/flashcards",
-        "/flashcards/**",
-        "http://10.0.0.9:5000/flashcards",
-        "http://10.0.0.9:5000/flashcards/**"
+        "/flashcards/api/flashcards",
+        "/flashcards/api/flashcards/**",
+        "http://10.0.0.9:5000/flashcards/api/flashcards",
+        "http://10.0.0.9:5000/flashcards/api/flashcards/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",


### PR DESCRIPTION
## Summary
- configure Angular router to use hash-based routing
- set `/flashcards/` as the base href in `index.html` and build options
- update nginx config to serve the app from `/flashcards`

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_687ab31009e0832a96b1cad1a3449826