### PR TITLE
Update base path for nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ docker-compose up
 ```
 
 ### API Docs (Swagger)
-Visit [http://localhost:5000/swagger](http://localhost:5000/swagger)
+Visit [http://localhost:5000/flashcards/api/swagger](http://localhost:5000/flashcards/api/swagger)
 
 ### 🔐 Authentication
 The backend secures admin routes using JWT tokens. Log in with the seeded

--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -7,7 +7,7 @@ The API uses JSON Web Tokens (JWT) for protected routes such as `/users`.
 Obtain a token with the seeded admin credentials:
 
 ```bash
-TOKEN=$(curl -s -X POST http://localhost:5000/users/login \
+TOKEN=$(curl -s -X POST http://localhost:5000/flashcards/api/users/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin123"}' | jq -r '.token')
 ```
@@ -17,7 +17,7 @@ TOKEN=$(curl -s -X POST http://localhost:5000/users/login \
 Include the token in the `Authorization` header for subsequent requests:
 
 ```bash
-curl -X GET http://localhost:5000/users \
+curl -X GET http://localhost:5000/flashcards/api/users \
   -H "accept: application/json" \
   -H "Authorization: Bearer $TOKEN"
 ```
@@ -33,7 +33,7 @@ To persist the token across shell sessions, save it and reload when needed:
 ```bash
 echo $TOKEN > ~/.flashcards-jwt
 export FLASHCARDS_JWT=$(cat ~/.flashcards-jwt)
-curl -X GET http://localhost:5000/users \
+curl -X GET http://localhost:5000/flashcards/api/users \
   -H "accept: application/json" \
   -H "Authorization: Bearer $FLASHCARDS_JWT"
 ```
@@ -44,7 +44,7 @@ Only admins can create new users. Send a `POST` request with `username`,
 `password` and optional `roles` fields:
 
 ```bash
-curl -X POST http://localhost:5000/users \
+curl -X POST http://localhost:5000/flashcards/api/users \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $FLASHCARDS_JWT" \
   -d '{"username":"bob","password":"secret","roles":["user"]}'

--- a/frontend/flashcards-ui/src/environments/environment.prod.ts
+++ b/frontend/flashcards-ui/src/environments/environment.prod.ts
@@ -1,7 +1,13 @@
+const host =
+  typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+const protocol =
+  typeof window !== 'undefined' ? window.location.protocol : 'http:';
+
 export const environment = {
   production: true,
-  // In production the API runs on the host machine. Update the base URL
-  // so mobile clients can reach it using the server's IP address.
-  apiBaseUrl: '/flashcards/api',
-  logLevel: 'info'
+  // In production the API runs on the host machine. Use the current
+  // hostname so mobile clients can reach it when served behind a
+  // reverse proxy.
+  apiBaseUrl: `${protocol}//${host}:5000/flashcards/api`,
+  logLevel: 'info',
 };


### PR DESCRIPTION
## Summary
- update prod environment to use dynamic host with `/flashcards/api`
- document new swagger URL
- update auth docs with new base path

## Testing
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ababc8098832a8bcd8a2049706aa2