### PR TITLE
Prefix API routes with BASE_PATH

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,11 @@ log_file = os.path.join(log_dir, 'backend.log')
 logging.basicConfig(level=logging.DEBUG, filename=log_file, filemode='a')
 
 BASE_PATH = os.getenv("BASE_PATH", "")
-app = FastAPI(title="Flashcards API (Python)", root_path=BASE_PATH)
+app = FastAPI(
+    title="Flashcards API (Python)",
+    docs_url=f"{BASE_PATH}/docs",
+    openapi_url=f"{BASE_PATH}/openapi.json",
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -40,9 +44,10 @@ user_service = UserService()
 
 from . import routes
 
-app.include_router(routes.router)
+app.include_router(routes.router, prefix=BASE_PATH)
 
 # Serve uploaded images
 images_dir = os.path.join(os.path.dirname(__file__), 'resources', 'images')
 os.makedirs(images_dir, exist_ok=True)
-app.mount('/images', StaticFiles(directory=images_dir), name='images')
+app.mount(f"{BASE_PATH}/images", StaticFiles(directory=images_dir), name='images')
+

--- a/frontend/flashcards-ui/nginx.conf
+++ b/frontend/flashcards-ui/nginx.conf
@@ -10,7 +10,10 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     location / {
-        return 301 /flashcards/;
+        # Redirect any request to the /flashcards/ base path while
+        # preserving the remainder of the original URI so deep links
+        # continue to work when accessed without the prefix.
+        return 301 /flashcards$request_uri;
     }
 
     location /flashcards/ {

--- a/frontend/flashcards-ui/proxy.conf.json
+++ b/frontend/flashcards-ui/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/flashcardbulkimport": {
-    "target": "http://10.0.0.9:5000/flashcards/api",
+    "target": "http://localhost:5000/flashcards/api",
     "secure": false
   }
 }

--- a/frontend/flashcards-ui/src/environments/environment.prod.ts
+++ b/frontend/flashcards-ui/src/environments/environment.prod.ts
@@ -9,9 +9,8 @@ export const environment = {
   // hostname so mobile clients can reach it when served behind a
   // reverse proxy.
   // In production the API is served behind an nginx reverse proxy at
-  // `/flashcards/api` on port 5000. Using the current hostname means
-  // the same build works when deployed behind a proxy without needing
-  // to hardcode the host IP.
-  apiBaseUrl: `${protocol}//${host}:5000/flashcards/api`,
+  // `/flashcards/api`. Requests should go to the same host and port
+  // that served the frontend, so the port is omitted.
+  apiBaseUrl: `${protocol}//${host}/flashcards/api`,
   logLevel: 'info',
 };

--- a/frontend/flashcards-ui/src/ngsw-config.json
+++ b/frontend/flashcards-ui/src/ngsw-config.json
@@ -30,9 +30,7 @@
       "name": "decks-api",
       "urls": [
         "/flashcards/api/decks",
-        "/flashcards/api/decks/**",
-        "http://10.0.0.9:5000/flashcards/api/decks",
-        "http://10.0.0.9:5000/flashcards/api/decks/**"
+        "/flashcards/api/decks/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",
@@ -45,9 +43,7 @@
       "name": "flashcards-api",
       "urls": [
         "/flashcards/api/flashcards",
-        "/flashcards/api/flashcards/**",
-        "http://10.0.0.9:5000/flashcards/api/flashcards",
-        "http://10.0.0.9:5000/flashcards/api/flashcards/**"
+        "/flashcards/api/flashcards/**"
       ],
       "cacheConfig": {
         "strategy": "freshness",


### PR DESCRIPTION
## Summary
- prefix backend routes with BASE_PATH
- mount images and docs under the BASE_PATH
- remove hardcoded host in Angular service worker and proxy
- use same host for API base in production builds
- redirect requests to the Angular base path

## Testing
- `pipenv run pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b58397dbc832abcf012f34c595a35