### PR TITLE
Add swipe gestures and vote stats to flashcard scroll view

### DIFF
--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.css
@@ -4,9 +4,19 @@
   height: 100vh;
 }
 
-.qa-section {
+.scroll-card {
   min-height: 100vh;
   scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  box-sizing: border-box;
+  gap: 1rem;
+}
+
+.qa-section {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -46,4 +56,8 @@
   white-space: pre-wrap;
   font-family: 'Courier New', monospace;
   font-size: 0.95rem;
+}
+
+.vote-stats {
+  font-family: 'Courier New', monospace;
 }

--- a/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
+++ b/frontend/flashcards-ui/src/app/flashcard/flashcard-scroll.component.html
@@ -1,33 +1,47 @@
 <div class="scroll-wrapper" *ngIf="flashcards.length">
   <ng-container *ngFor="let card of flashcards">
-    <section class="qa-section question">
-      <img
-        *ngIf="card.questionImage"
-        [src]="apiUrl + '/images/' + card.questionImage"
-        class="flashcard-image"
-        alt="question image"
-      />
-      <pre class="card-text question-text">{{ card.question }}</pre>
-      <div class="d-flex justify-content-center mt-3">
-        <button class="btn btn-success me-2" (click)="vote(card, true)">👍</button>
-        <button class="btn btn-danger me-2" (click)="vote(card, false)">👎</button>
-        <button class="btn btn-warning me-2" (click)="readAloud(card)">🔊 Voice</button>
-      </div>
-    </section>
-    <section class="qa-section answer">
-      <app-flashcard-answer
-        [answer]="card.answer"
-        [image]="card.answerImage || ''"
-      ></app-flashcard-answer>
-      <div *ngIf="card.explanation" class="alert alert-info text-start mt-3">
+    <div
+      class="scroll-card"
+      (pointerdown)="onPointerStart($event, card)"
+      (pointerup)="onPointerEnd($event, card)"
+      (pointercancel)="onPointerCancel()"
+      (pointerleave)="onPointerCancel()"
+    >
+      <section class="qa-section question" *ngIf="!card.showAnswer">
         <img
-          *ngIf="card.explanationImage"
-          [src]="apiUrl + '/images/' + card.explanationImage"
+          *ngIf="card.questionImage"
+          [src]="apiUrl + '/images/' + card.questionImage"
           class="flashcard-image"
-          alt="explanation image"
+          alt="question image"
         />
-        {{ card.explanation }}
+        <pre class="card-text question-text">{{ card.question }}</pre>
+      </section>
+
+      <section class="qa-section answer" *ngIf="card.showAnswer">
+        <app-flashcard-answer
+          [answer]="card.answer"
+          [image]="card.answerImage || ''"
+        ></app-flashcard-answer>
+        <div *ngIf="card.explanation" class="alert alert-info text-start mt-3">
+          <img
+            *ngIf="card.explanationImage"
+            [src]="apiUrl + '/images/' + card.explanationImage"
+            class="flashcard-image"
+            alt="explanation image"
+          />
+          {{ card.explanation }}
+        </div>
+      </section>
+
+      <div class="d-flex justify-content-center align-items-center flex-wrap mt-3 gap-2">
+        <button class="btn btn-success" (click)="vote(card, true)">👍</button>
+        <button class="btn btn-danger" (click)="vote(card, false)">👎</button>
+        <button class="btn btn-warning" (click)="readAloud(card)">🔊 Voice</button>
+        <div class="vote-stats text-muted">
+          👍 {{ card.stats?.up ?? 0 }} · 👎 {{ card.stats?.down ?? 0 }}
+        </div>
       </div>
-    </section>
+      <div class="text-center text-muted mt-2 small">Swipe right 👍, left 👎, up 🔄</div>
+    </div>
   </ng-container>
 </div>

--- a/frontend/flashcards-ui/src/app/services/local-score.service.ts
+++ b/frontend/flashcards-ui/src/app/services/local-score.service.ts
@@ -1,10 +1,17 @@
 import { Injectable } from '@angular/core';
 
+export interface ScoreStats {
+  up: number;
+  down: number;
+}
+
+type StoredScore = number | ScoreStats | undefined;
+
 @Injectable({ providedIn: 'root' })
 export class LocalScoreService {
   private storageKey = 'flashcardScores';
 
-  private load(): Record<string, number> {
+  private loadRaw(): Record<string, StoredScore> {
     const raw = localStorage.getItem(this.storageKey);
     if (!raw) {
       return {};
@@ -16,17 +23,51 @@ export class LocalScoreService {
     }
   }
 
-  private save(scores: Record<string, number>): void {
+  private normalizeScores(): Record<string, ScoreStats> {
+    const raw = this.loadRaw();
+    const normalized: Record<string, ScoreStats> = {};
+    Object.keys(raw).forEach(key => {
+      const value = raw[key];
+      if (typeof value === 'number') {
+        normalized[key] = { up: value, down: 0 };
+      } else if (value && typeof value === 'object') {
+        const up = typeof value.up === 'number' ? value.up : 0;
+        const down = typeof value.down === 'number' ? value.down : 0;
+        normalized[key] = { up, down };
+      }
+    });
+    return normalized;
+  }
+
+  private save(scores: Record<string, ScoreStats>): void {
     localStorage.setItem(this.storageKey, JSON.stringify(scores));
   }
 
   getScore(id: string): number {
-    return this.load()[id] ?? 0;
+    return this.getStats(id).up;
+  }
+
+  getStats(id: string): ScoreStats {
+    const scores = this.normalizeScores();
+    return scores[id] ?? { up: 0, down: 0 };
   }
 
   setScore(id: string, score: number): void {
-    const scores = this.load();
-    scores[id] = score;
+    const scores = this.normalizeScores();
+    const existing = scores[id] ?? { up: 0, down: 0 };
+    scores[id] = { ...existing, up: score };
     this.save(scores);
+  }
+
+  recordVote(id: string, upVote: boolean): ScoreStats {
+    const scores = this.normalizeScores();
+    const current = scores[id] ?? { up: 0, down: 0 };
+    const updated = {
+      up: upVote ? current.up + 1 : current.up,
+      down: upVote ? current.down : current.down + 1,
+    };
+    scores[id] = updated;
+    this.save(scores);
+    return updated;
   }
 }


### PR DESCRIPTION
## Summary
- add swipe gesture handling to the flashcard scroll experience to upvote, downvote, or flip a card
- surface per-card vote totals and instructions alongside the manual action buttons
- extend the local score service to store both up and down counts while keeping existing consumers working

## Testing
- npm run test *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68f2018fdf28832ab8c3db4316f81c29