### PR TITLE
Add Android, database, and user management specs

### DIFF
--- a/spec/android.md
+++ b/spec/android.md
@@ -1,0 +1,23 @@
+# Flashcards Android Frontend Spec
+
+This guide summarizes the native Android client housed in `frontend/flashcards-android/`, focusing on structure, configuration, and how it mirrors the web experience for downstream LLM agents.
+
+## Architecture & Tech Stack
+- **Jetpack Compose UI with MVVM/Clean Architecture**: Presentation screens under `presentation/` consume domain `ViewModel`s that delegate to repository and data layers, keeping UI declarative and state-driven.【F:frontend/flashcards-android/README.md†L8-L47】
+- **Dependency Injection**: Hilt modules in `di/` wire Retrofit, Room, and DataStore so screens can request typed interfaces without manual wiring.【F:frontend/flashcards-android/README.md†L23-L49】
+- **Networking & Local Storage**: Retrofit + OkHttp handle REST calls to the FastAPI backend; Room and DataStore back offline caching and secure preference storage (e.g., JWT token).【F:frontend/flashcards-android/README.md†L10-L16】【F:frontend/flashcards-android/README.md†L55-L80】
+
+## Project Layout
+- **Data Layer**: `data/local` (DAOs, entities, database) and `data/remote` (API interfaces, DTOs, interceptors) provide the persistence and network surface; `data/repository` coordinates them.【F:frontend/flashcards-android/README.md†L23-L35】
+- **Domain Layer**: `domain/model`, `domain/repository`, and `domain/usecase` capture business logic independently of framework code.【F:frontend/flashcards-android/README.md†L35-L38】
+- **Presentation Layer**: Compose screens live under `presentation/` (`auth`, `home`, `decks`, `flashcards`, `study`, `learningpaths`, `settings`) with a central navigation graph in `presentation/navigation`.【F:frontend/flashcards-android/README.md†L39-L49】
+- **Build & Config**: Base URL is injected via `build.gradle.kts` (`API_BASE_URL`) with emulator-friendly defaults (`10.0.2.2:5000`).【F:frontend/flashcards-android/README.md†L123-L133】 Configure `local.properties` to match your backend host when running on device.【F:frontend/flashcards-android/README.md†L94-L104】
+
+## Feature Parity Targets
+- **Core flows**: Login, deck/flashcard CRUD, study mode with swipe gestures, learning paths, and user settings mirror the Angular UI feature set.【F:frontend/flashcards-android/README.md†L60-L67】
+- **Mobile extensions**: Biometric auth, dark mode, gesture navigation, and offline sync are planned but gated behind roadmap checklists for prioritization.【F:frontend/flashcards-android/README.md†L73-L181】
+
+## Integration Notes
+- **API surface**: Align Retrofit interfaces with FastAPI routes (see backend spec) and include JWT auth headers once tokens are issued by `/users/login`.
+- **Offline strategy**: Cache decks/flashcards in Room, queue mutations when offline, and replay once connectivity resumes (per offline support goals).【F:frontend/flashcards-android/README.md†L175-L181】
+- **Security**: Store tokens in encrypted DataStore, enable certificate pinning, and leverage biometric prompts where available to guard study sessions.【F:frontend/flashcards-android/README.md†L182-L187】

--- a/spec/backend.md
+++ b/spec/backend.md
@@ -1,0 +1,44 @@
+# Backend Reference (FastAPI)
+
+This guide summarizes the FastAPI backend for LLM agents. It focuses on service responsibilities, routing, storage, and LLM usage so assistants can reason about behaviors without re-reading the codebase.
+
+## Application Composition
+- `app/main.py` wires the FastAPI instance, enables permissive CORS, loads environment variables from `.env.dev` or `.env.production`, and constructs long-lived services for decks, flashcards, learning paths, and users. It also serves uploaded images from `app/resources/images`.【F:backend/app/main.py†L1-L40】
+- Qdrant host/port default to `10.0.0.9:6334`; logging writes to `backend/logging/backend.log` created on startup.【F:backend/app/main.py†L13-L38】
+
+## Domain Services
+- **QdrantFlashcardService** ensures the `flashcards` collection exists with cosine distance and embeds primary questions (falling back to a zero vector) before upserting points. It normalizes IDs to UUID strings, keeps deck indexes fresh, and exposes CRUD/scroll helpers such as `get_all`, `get_random`, `query_by_vector`, and `cleanup_image_fields` (see implementation for additional utilities).【F:backend/app/services/qdrant_flashcard_service.py†L1-L107】
+- **Deck + Learning Path services** mirror the flashcard service pattern to store deck metadata and learning path definitions in Qdrant. Deck coverage can be updated programmatically (see `/decks/{deck_id}/coverage`).【F:backend/app/routes.py†L117-L156】
+- **UserService** (in-memory) supports credential validation, hashing, role assignment, and settings persistence used by auth routes. JWT signing keys, issuer, audience, and expiry are read from environment variables before issuing tokens.【F:backend/app/routes.py†L170-L220】
+- **LLMService** exposes async `transform_question` and `ask` methods plus sync `coverage` calculations. Providers are selected by `LLM_PROVIDER` (`openai` default, `deepseek` alternative). Prompts are configurable via `LLM_SYSTEM_PROMPT` and `QUESTION_TRANSFORM_PROMPT`. Responses are parsed from JSON, with graceful fallback to raw content on parse errors.【F:backend/app/services/llm_service.py†L12-L187】
+
+## API Surface
+Routes live in `app/routes.py` and are registered under the root router. Key families include:
+
+- **Flashcards**
+  - `POST /flashcards` (alias `/Flashcards`): create and index flashcards.
+  - `GET /flashcards`: list all flashcards.
+  - `PUT /flashcards/{id}` / `PATCH /flashcards/{id}/score` / `DELETE /flashcards/{id}`: update, score, or remove flashcards.
+  - `GET /flashcards/random` and `GET /flashcards/{deckId}/random`: sample cards globally or by deck.
+  - `POST /flashcards/query-vector` and `POST /flashcards/query-string`: vector and semantic searches that return cards (and optional similarity scores).【F:backend/app/routes.py†L39-L111】【F:backend/app/routes.py†L129-L155】
+
+- **Decks & Coverage**
+  - `GET /decks`: list decks, refreshing coverage cache daily by rebuilding from flashcards when needed.
+  - `POST /decks/{deck_id}/coverage`: recompute LLM-based coverage for the given deck’s questions.
+  - `PUT /decks/{deck_id}`: rename decks and update descriptions while rebuilding indexes.【F:backend/app/routes.py†L101-L156】
+
+- **Learning Paths**
+  - CRUD endpoints under `/api/learning-paths` plus a seeding endpoint for bundled JSON data.【F:backend/app/routes.py†L157-L199】
+
+- **Auth & Users**
+  - `POST /users/login`: validate credentials and issue JWTs signed with the configured key, issuer, audience, and expiry.
+  - Standard CRUD for users at `/users` plus `/users/{id}/settings` for updating preferences. Adding users hashes the provided password before persistence.【F:backend/app/routes.py†L170-L232】
+
+- **AI Generation & Bulk Ops**
+  - `POST /api/generate/flashcards`: transform a prompt, request answer/explanation JSON from the LLM, and return a `Flashcard` payload with the transformed question in `question` and `questions`.
+  - Bulk import/export endpoints under `/FlashcardBulkImport/upload-json` and `/FlashcardBulkExport/export-json` support deduplication by normalized question text when importing.【F:backend/app/routes.py†L234-L279】
+
+## Data Shape Considerations
+- Pydantic models define aliases for camelCase compatibility. The backend normalizes IDs that may arrive as `{"uuid": "..."}` or JSON strings to plain UUIDs before writing to Qdrant or validating route path parameters.【F:backend/app/models.py†L13-L62】【F:backend/app/services/qdrant_flashcard_service.py†L75-L105】
+- Deck cache rebuilds rely on `main.deck_service.rebuild_from_flashcards` to synchronize derived deck metadata after flashcard mutations. For consistent coverage metrics, trigger `PUT /decks/{deck_id}` or `POST /decks/{deck_id}/coverage` following bulk updates.【F:backend/app/routes.py†L101-L156】
+

--- a/spec/database.md
+++ b/spec/database.md
@@ -1,0 +1,19 @@
+# Flashcards Data & Storage Spec
+
+This reference outlines how the platform persists flashcards, decks, learning paths, users, and assets so downstream agents can reason about migrations or integrations.
+
+## Qdrant Collections
+- **Flashcards (`flashcards`)**: Each upsert stores a `Flashcard` payload keyed by UUID string. Embeddings (size 384, cosine distance) derive from the primary question; IDs are normalized when missing or in `{ "uuid": ... }` shape.【F:backend/app/services/qdrant_flashcard_service.py†L34-L95】
+- **Decks (`decks`)**: Rebuilt from flashcards with deterministic IDs (UUID or UUIDv5) and coverage/count metadata preserved in payload JSON. Collection uses a 1-dim vector placeholder for cosine distance consistency.【F:backend/app/services/qdrant_deck_service.py†L41-L126】
+- **Learning Paths (`learning_paths`)**: Stores serialized `LearningPath` JSON with generated or normalized UUIDs; collection created at startup with 64-dim zeroed vectors to satisfy Qdrant schema.【F:backend/app/services/qdrant_learning_path_service.py†L23-L115】
+- **Connection config**: All collections connect via gRPC using `QDRANT_HOST`/`QDRANT_PORT` envs (default `10.0.0.9:6334`) during FastAPI startup.【F:backend/app/main.py†L33-L39】
+
+## File-Backed Data
+- **Users**: JSON file at `data/users.json` holds user records. On first run, the service seeds an admin account (`admin` / `admin123`) and persists subsequent changes with SHA-256 password hashes.【F:backend/app/services/user_service.py†L12-L67】
+- **Images**: Uploaded assets are written to `backend/app/resources/images/` and served via the `/images` StaticFiles mount for frontend consumption.【F:backend/app/main.py†L45-L48】【F:backend/app/routes.py†L394-L417】
+- **Seeds**: Optional JSON seed files (`flashcards.json`, `learning-paths.json`) live under `backend/app/resources/` and can populate Qdrant via dedicated endpoints (`/Flashcards/seed`, `/api/learning-paths/seed`).【F:backend/app/routes.py†L213-L267】
+
+## Operational Notes
+- Rebuilding decks happens automatically when flashcards are indexed or deleted, ensuring deck counts stay synchronized with Qdrant payloads.【F:backend/app/services/qdrant_flashcard_service.py†L53-L146】
+- Coverage updates write back to the `decks` collection and are typically triggered after LLM-driven scoring runs per deck.【F:backend/app/routes.py†L89-L119】【F:backend/app/services/qdrant_deck_service.py†L112-L118】
+- Queries support both vector search (`/Flashcards/query-vector`, `/Flashcards/query-string`) and random sampling (`/Flashcards/random`, `/Flashcards/{deckId}/random`) for study modes; ensure embeddings stay aligned with the configured vector size (384).【F:backend/app/routes.py†L120-L206】【F:backend/app/services/qdrant_flashcard_service.py†L34-L190】

--- a/spec/frontend.md
+++ b/spec/frontend.md
@@ -1,0 +1,31 @@
+# Frontend Reference (Angular)
+
+This document orients LLM agents to the Angular PWA housed in `frontend/flashcards-ui`. It highlights navigation, services, and environment assumptions relevant to coordinating with the backend and vector store.
+
+## Navigation & Routing
+- Routes in `app.routes.ts` map core experiences:
+  - `/` → `HomeComponent` for deck selection and entry into study mode.
+  - `/deck/:deckId` → `FlashcardComponent` for per-deck practice.
+  - `/manage-flashcards` → `FlashcardAdminComponent` for CRUD and bulk actions.
+  - `/manage-images` → `ImageManagerComponent` for uploaded assets.
+  - `/learning-paths` → `LearningPathComponent` for guided sequences.
+  - `/bulk-import` → `FlashcardBulkImportComponent` for JSON imports.
+  - `/login` and `/admin/users` provide auth and user administration (the latter gated by `AdminGuard`).
+  - `/settings` exposes user preferences such as font size; `/about` and `/help` cover reference content.【F:frontend/flashcards-ui/src/app/app.routes.ts†L1-L24】
+
+## API Services
+- **FlashcardService** (`services/flashcard.service.ts`)
+  - Targets `${apiBaseUrl}/flashcards` for list/create/update/delete plus score updates and random draws per deck.
+  - Normalizes IDs that may arrive as objects (e.g., `{uuid: ...}`) or JSON strings before sending mutations to keep backend and Qdrant storage consistent.【F:frontend/flashcards-ui/src/app/services/flashcard.service.ts†L1-L69】
+  - Wraps AI generation (`POST /api/generate/flashcards`), database reseeding, and image cleanup helpers for admin workflows.【F:frontend/flashcards-ui/src/app/services/flashcard.service.ts†L70-L86】
+
+- **DeckService** (`services/deck.service.ts`)
+  - Reads deck metadata from `${apiBaseUrl}/decks` and triggers coverage recomputation via `POST /decks/{id}/coverage`.
+  - Supports deck rename/description updates through `PUT /decks/{id}` used by admin tooling.【F:frontend/flashcards-ui/src/app/services/deck.service.ts†L1-L24】
+
+Additional services (auth guard, user, logger, learning paths) follow similar patterns of lightweight HttpClient wrappers pointing at the FastAPI routes described in `spec/backend.md`.
+
+## Environment & Hosting
+- `environment.ts` sets `apiBaseUrl` dynamically based on the browser’s current protocol/hostname with port `5000`, enabling local LAN testing without manual configuration. Logging defaults to `debug` for development builds.【F:frontend/flashcards-ui/src/environments/environment.ts†L1-L11】
+- Ensure the backend CORS settings remain permissive (see `spec/backend.md`) when serving the Angular app from `ng serve` or Docker Compose.
+

--- a/spec/overview.md
+++ b/spec/overview.md
@@ -1,0 +1,27 @@
+# Flashcards App – System Overview
+
+This document summarizes the Flashcards AI Learning App for downstream LLM agents. It highlights the high-level purpose, platform layout, and primary data structures so the rest of the spec set can be navigated quickly.
+
+## Product Goals
+- Provide an AI-assisted flashcard learning platform with deck-based study, admin tools, and learning paths. The stack pairs an Angular PWA frontend with a FastAPI backend, Qdrant vector storage, and LLM-powered generation and coverage estimation.【F:README.md†L1-L76】【F:README.md†L96-L124】
+
+## Top-Level Architecture
+- **Frontend (Angular 17)** lives in `frontend/flashcards-ui` and exposes study, admin, image management, authentication, and learning-path views. Routes map directly to components such as `HomeComponent`, `FlashcardComponent`, `FlashcardAdminComponent`, and `LearningPathComponent`. Admin-only screens use `AdminGuard`.【F:frontend/flashcards-ui/src/app/app.routes.ts†L1-L24】
+- **Backend (FastAPI)** initializes Qdrant-backed services for flashcards, decks, and learning paths, plus an in-memory user service. CORS is open for all origins to support local development and mobile access.【F:backend/app/main.py†L1-L39】
+- **Vector store (Qdrant)** holds flashcards with embeddings generated via the backend embedding service. The FastAPI layer ensures the collection exists and keeps deck metadata in sync after writes.【F:backend/app/services/qdrant_flashcard_service.py†L1-L75】【F:backend/app/services/qdrant_flashcard_service.py†L90-L106】
+- **LLM integrations** power question transformation, flashcard generation, and deck coverage scoring. Providers are selected by `LLM_PROVIDER`, supporting OpenAI or DeepSeek with configurable prompts.【F:backend/app/services/llm_service.py†L12-L92】【F:backend/app/services/llm_service.py†L118-L187】
+
+## Core Data Model
+- **Flashcard** objects carry IDs (normalized to UUID strings), primary and alternate questions, answer, explanation, optional images, topic, score, and deck association. Aliases (e.g., `deckId`, `questionImage`) support client compatibility. Validation syncs `question` and `questions` fields when one is missing.【F:backend/app/models.py†L13-L62】
+- **Deck** summarizes grouped flashcards with a description and coverage metric; **LearningPath** links card IDs and topics for guided study flows.【F:backend/app/models.py†L64-L102】
+- **User/UserSettings** provide auth metadata and preferences such as flashcard font size. `AddUserRequest` allows plain password creation for seeding/admin flows.【F:backend/app/models.py†L104-L140】
+
+## Key User Journeys
+- **Study:** Learners browse decks and pull random cards per deck. Backend routes expose `/flashcards/{deckId}/random` and `/flashcards/random` for general practice.【F:backend/app/routes.py†L60-L99】
+- **Manage content:** Admins add, update, delete, bulk import/export flashcards, normalize images, and rebuild decks. Coverage refresh uses LLM-based scoring per deck.【F:backend/app/routes.py†L17-L188】【F:backend/app/routes.py†L201-L250】
+- **Generate with AI:** Users submit a question; the backend transforms it and calls the configured LLM to return answer/explanation JSON, packaged as a new `Flashcard` response.【F:backend/app/routes.py†L252-L268】【F:backend/app/services/llm_service.py†L12-L92】
+
+## Environment Expectations
+- Frontend assumes the API base URL matches the current host on port `5000`, enabling LAN access when serving locally (`ng serve --host 0.0.0.0`).【F:frontend/flashcards-ui/src/environments/environment.ts†L1-L11】
+- Backend defaults to `QDRANT_HOST=10.0.0.9`, `QDRANT_PORT=6334`, and JWT/LLM secrets loaded from `.env.dev` or `.env.production` depending on `ENV`. Logs write to `backend/logging/backend.log`.【F:backend/app/main.py†L1-L38】
+

--- a/spec/user-management.md
+++ b/spec/user-management.md
@@ -1,0 +1,20 @@
+# User Management Spec
+
+Guidance for authentication, authorization, and profile storage across the Flashcards stack.
+
+## Identity & Storage
+- Users are persisted in `data/users.json` with SHA-256 password hashes; missing storage triggers seeding of an `admin` account (`admin` / `admin123`) to ensure initial access.【F:backend/app/services/user_service.py†L12-L67】
+- User records include roles (default `user`) and nested `UserSettings` (e.g., `flashcardFontSize`).【F:backend/app/models.py†L104-L140】
+
+## Authentication
+- **Login**: `/users/login` validates credentials against stored hashes. On success it issues an HS256 JWT containing user id, username, roles, issuer/audience claims, and an expiry driven by `JWT_EXPIRE_MINUTES` (default 60).【F:backend/app/routes.py†L269-L295】
+- **Token handling**: Clients must present the JWT in subsequent API calls (frontend Retrofit/Angular interceptors) to gate admin-only features; the backend currently exposes routes without per-endpoint guards, so client-side role checks are essential.
+
+## User CRUD & Settings
+- **List/Create**: `/users` supports listing all users and creating new ones from `AddUserRequest`, hashing the supplied plain password before persistence.【F:backend/app/routes.py†L298-L313】
+- **Read/Update/Delete**: `/users/{id}` fetches, updates (ID-mismatch guarded), or deletes a specific user record.【F:backend/app/routes.py†L315-L334】
+- **Settings**: `/users/{id}/settings` replaces the `UserSettings` payload for a user after existence validation.【F:backend/app/routes.py†L337-L344】
+
+## Client Responsibilities
+- Persist tokens securely (Angular local storage or Android encrypted DataStore) and include them on admin-scope routes (e.g., bulk flashcard operations, coverage refresh).
+- Enforce role-aware UI controls (e.g., only admins can reach deck rebuild or bulk import/export flows) until backend authorization middleware is introduced.


### PR DESCRIPTION
## Summary
- add an Android frontend spec summarizing architecture, layout, and integration notes
- document the storage model across Qdrant collections, seed files, and file-backed assets
- describe user authentication, CRUD endpoints, and client responsibilities for role handling

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d609f0f50832abdf6302694654505)